### PR TITLE
Redesign TUI with dark theme, execution history, and WinGet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ Using DSC v3 configuration files, you can consolidate manual machine setup and p
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download)
 - [PowerShell 7](https://github.com/PowerShell/PowerShell/releases) (pwsh)
-- [DSC v3 Preview](https://github.com/PowerShell/DSC/releases) (>= 3.2) — install via `winget install Microsoft.DSC.Preview`
+- [DSC v3 Preview](https://github.com/PowerShell/DSC/releases) (>= 3.2.2) — install via `winget install Microsoft.DSC.Preview`
 - Windows (admin recommended for applying profiles)
 
 > **Note:** DSC v3 Preview >= 3.2 is required for the `Microsoft.DSC.Transitional/RunCommandOnSet` resource used by VSCode extension and dotnet tool installation. The stable DSC v3 release (3.1.x) does not include this resource.
+
+> **Known issue — DSC v3 `3.2.0-preview.12` (version `3.2.12.0`):** This version has a bug where `dsc config test` and `dsc config set` fail with `"JSON: trailing characters at line 2 column 1"` for all WinGet resources. DSC successfully invokes `winget dscv3 package --test` and gets valid results, but then crashes during its own JSON verification step (exit code 2, no output). This affects every profile containing `Microsoft.WinGet/Package` resources. The `atc-dsc` tool handles this gracefully by showing "Failed to parse DSC output as JSON". To work around this, downgrade to a working version:
+>
+> ```powershell
+> winget uninstall Microsoft.DSC.Preview
+> winget install Microsoft.DSC.Preview --version 3.2.2
+> ```
 
 ## 🚀 Applying Profiles
 

--- a/src/Atc.Dsc.Configurations.Cli/Clients/WinGetClient.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Clients/WinGetClient.cs
@@ -1,0 +1,280 @@
+namespace Atc.Dsc.Configurations.Cli.Clients;
+
+/// <summary>
+/// Queries the local WinGet installation to determine installed package
+/// versions and available upgrades. Results are cached for the session.
+/// Parsing logic follows the approach used by winget-tui (Rust).
+/// </summary>
+public sealed class WinGetClient
+{
+    private Dictionary<string, WinGetPackageInfo>? cache;
+
+    /// <summary>
+    /// Gets package info for a specific package ID (case-insensitive).
+    /// Returns <see langword="null"/> if the package is not installed.
+    /// </summary>
+    /// <param name="packageId">the WinGet package identifier.</param>
+    /// <param name="cancellationToken">a cancellation token.</param>
+    /// <returns>The package info, or <see langword="null"/>.</returns>
+    public async Task<WinGetPackageInfo?> GetPackageAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+    {
+        var packages = await GetAllPackagesAsync(cancellationToken);
+        packages.TryGetValue(packageId, out var info);
+        return info;
+    }
+
+    /// <summary>
+    /// Loads and caches all installed WinGet packages.
+    /// </summary>
+    /// <param name="cancellationToken">a cancellation token.</param>
+    /// <returns>A dictionary of package ID to info.</returns>
+    internal async Task<Dictionary<string, WinGetPackageInfo>> GetAllPackagesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (cache is not null)
+        {
+            return cache;
+        }
+
+        cache = await LoadInstalledPackagesAsync(cancellationToken);
+        return cache;
+    }
+
+    internal static async Task<Dictionary<string, WinGetPackageInfo>> LoadInstalledPackagesAsync(
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
+
+            var result = await CliWrap.Cli
+                .Wrap("winget")
+                .WithArguments([
+                    "list",
+                    "--source", "winget",
+                    "--accept-source-agreements",
+                    "--disable-interactivity",
+                ])
+                .WithValidation(CommandResultValidation.None)
+                .ExecuteBufferedAsync(cts.Token);
+
+            return ParseWinGetListOutput(result.StandardOutput);
+        }
+        catch (Exception ex) when (
+            ex is OperationCanceledException or Win32Exception or FileNotFoundException)
+        {
+            return new Dictionary<string, WinGetPackageInfo>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// Parses the tabular output of <c>winget list</c>.
+    /// Uses column-position detection from the header line,
+    /// following the approach from winget-tui (Rust).
+    /// </summary>
+    /// <param name="output">the raw stdout from winget list.</param>
+    /// <returns>A dictionary of package ID to info.</returns>
+    internal static Dictionary<string, WinGetPackageInfo> ParseWinGetListOutput(
+        string output)
+    {
+        var result = new Dictionary<string, WinGetPackageInfo>(StringComparer.OrdinalIgnoreCase);
+        var cleaned = CleanProgressOutput(output);
+        var lines = cleaned.Split('\n');
+
+        var separatorIndex = FindSeparatorLine(lines);
+        if (separatorIndex < 1)
+        {
+            return result;
+        }
+
+        var header = lines[separatorIndex - 1];
+        var columns = DetectColumns(header);
+
+        if (!columns.TryGetValue("Id", out var idCol) ||
+            !columns.TryGetValue("Version", out var versionCol))
+        {
+            return result;
+        }
+
+        columns.TryGetValue("Available", out var availableCol);
+
+        for (var i = separatorIndex + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (IsFooterLine(line))
+            {
+                break;
+            }
+
+            var info = ParsePackageLine(
+                line,
+                idCol,
+                versionCol,
+                availableCol);
+
+            if (info is not null)
+            {
+                result[info.Id] = info;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Strips winget progress bar <c>\r</c> overwrites from output.
+    /// Winget uses <c>\r</c> to overwrite spinner text in-place.
+    /// </summary>
+    /// <param name="output">the raw stdout from winget.</param>
+    /// <returns>Cleaned output with progress overwrites removed.</returns>
+    internal static string CleanProgressOutput(string output)
+    {
+        var normalized = output.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var sb = new StringBuilder(normalized.Length);
+
+        foreach (var rawLine in normalized.Split('\n'))
+        {
+            if (rawLine.Contains('\r', StringComparison.Ordinal))
+            {
+                // Keep only the final segment after last \r
+                var lastCr = rawLine.LastIndexOf('\r');
+                sb.Append(rawLine[(lastCr + 1)..]);
+            }
+            else
+            {
+                sb.Append(rawLine);
+            }
+
+            sb.Append('\n');
+        }
+
+        return sb.ToString();
+    }
+
+    private static int FindSeparatorLine(string[] lines)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].TrimEnd();
+            if (trimmed.Length > 10 && IsSeparator(trimmed))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsSeparator(string line)
+        => line.All(c => c is '-' or ' ');
+
+    private static Dictionary<string, int> DetectColumns(string header)
+    {
+        var columns = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var i = 0;
+
+        while (i < header.Length)
+        {
+            // Skip whitespace
+            while (i < header.Length && header[i] == ' ')
+            {
+                i++;
+            }
+
+            if (i >= header.Length)
+            {
+                break;
+            }
+
+            var start = i;
+
+            // Read word
+            while (i < header.Length && header[i] != ' ')
+            {
+                i++;
+            }
+
+            var word = header[start..i];
+            columns[word] = start;
+        }
+
+        return columns;
+    }
+
+    private static WinGetPackageInfo? ParsePackageLine(
+        string line,
+        int idCol,
+        int versionCol,
+        int availableCol)
+    {
+        if (line.Length <= idCol)
+        {
+            return null;
+        }
+
+        var id = ExtractField(line, idCol, versionCol).Trim();
+
+        // Validate ID: must contain . or \ to be a real package ID
+        if (id.Length == 0 ||
+            (!id.Contains('.', StringComparison.Ordinal) &&
+             !id.Contains('\\', StringComparison.Ordinal)))
+        {
+            return null;
+        }
+
+        var versionEnd = availableCol > 0 ? availableCol : line.Length;
+        var version = ExtractField(line, versionCol, versionEnd).Trim();
+
+        string? available = null;
+        if (availableCol > 0 && line.Length > availableCol)
+        {
+            var av = line[availableCol..].Trim();
+            if (av.Length > 0)
+            {
+                // Strip trailing source column (e.g. "winget")
+                var spaceIdx = av.IndexOf(' ', StringComparison.Ordinal);
+                available = spaceIdx > 0 ? av[..spaceIdx] : av;
+            }
+        }
+
+        return new WinGetPackageInfo(id, version, available);
+    }
+
+    private static string ExtractField(
+        string line,
+        int start,
+        int end)
+    {
+        if (start >= line.Length)
+        {
+            return string.Empty;
+        }
+
+        var actualEnd = System.Math.Min(end, line.Length);
+        return line[start..actualEnd];
+    }
+
+    private static bool IsFooterLine(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length == 0)
+        {
+            return false;
+        }
+
+        // Footer: "36 upgrades available." — digits only before the first space
+        if (char.IsDigit(trimmed[0]))
+        {
+            var spaceIdx = trimmed.IndexOf(' ', StringComparison.Ordinal);
+            if (spaceIdx > 0 && trimmed[..spaceIdx].All(char.IsDigit))
+            {
+                return true;
+            }
+        }
+
+        return trimmed.StartsWith("The following", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Atc.Dsc.Configurations.Cli/Contracts/EnvironmentInfo.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Contracts/EnvironmentInfo.cs
@@ -2,9 +2,11 @@ namespace Atc.Dsc.Configurations.Cli.Contracts;
 
 /// <summary>
 /// Snapshot of the runtime environment captured once at startup:
-/// admin elevation and DSC CLI availability.
+/// admin elevation, DSC CLI, and WinGet availability.
 /// </summary>
 public sealed record EnvironmentInfo(
     bool IsAdmin,
     bool DscCliAvailable,
-    string? DscCliVersion);
+    string? DscCliVersion,
+    bool WinGetAvailable,
+    string? WinGetVersion);

--- a/src/Atc.Dsc.Configurations.Cli/Contracts/HistoryEntry.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Contracts/HistoryEntry.cs
@@ -1,0 +1,15 @@
+namespace Atc.Dsc.Configurations.Cli.Contracts;
+
+/// <summary>
+/// A single execution history record persisted to disk.
+/// </summary>
+public sealed record HistoryEntry(
+    string ProfileName,
+    string FileName,
+    ExecutionMode Mode,
+    bool Success,
+    int TotalResources,
+    int PassedResources,
+    int FailedResources,
+    double DurationSeconds,
+    DateTimeOffset Timestamp);

--- a/src/Atc.Dsc.Configurations.Cli/Contracts/WinGetPackageInfo.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Contracts/WinGetPackageInfo.cs
@@ -1,0 +1,9 @@
+namespace Atc.Dsc.Configurations.Cli.Contracts;
+
+/// <summary>
+/// Installed WinGet package with version and optional available upgrade.
+/// </summary>
+public sealed record WinGetPackageInfo(
+    string Id,
+    string InstalledVersion,
+    string? AvailableVersion);

--- a/src/Atc.Dsc.Configurations.Cli/Diagnostics/EnvironmentDetector.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Diagnostics/EnvironmentDetector.cs
@@ -12,11 +12,14 @@ public sealed class EnvironmentDetector : IEnvironmentDetector
         var isAdmin = OperatingSystem.IsWindows() && CheckIsAdmin();
 
         var (dscAvailable, dscVersion) = await ProbeVersionAsync("dsc", cancellationToken);
+        var (winGetAvailable, winGetVersion) = await ProbeVersionAsync("winget", cancellationToken);
 
         return new EnvironmentInfo(
             isAdmin,
             dscAvailable,
-            dscVersion);
+            dscVersion,
+            winGetAvailable,
+            winGetVersion);
     }
 
     [SupportedOSPlatform("windows")]

--- a/src/Atc.Dsc.Configurations.Cli/GlobalUsings.cs
+++ b/src/Atc.Dsc.Configurations.Cli/GlobalUsings.cs
@@ -22,6 +22,7 @@ global using Atc.Dsc.Configurations.Cli.Diagnostics;
 global using Atc.Dsc.Configurations.Cli.Extensions;
 global using Atc.Dsc.Configurations.Cli.Parsers;
 global using Atc.Dsc.Configurations.Cli.Repositories;
+global using Atc.Dsc.Configurations.Cli.Services;
 global using Atc.Dsc.Configurations.Cli.Tui;
 global using Atc.Dsc.Configurations.Cli.Tui.Theme;
 global using Atc.Dsc.Configurations.Cli.Tui.Views;

--- a/src/Atc.Dsc.Configurations.Cli/GlobalUsings.cs
+++ b/src/Atc.Dsc.Configurations.Cli/GlobalUsings.cs
@@ -23,6 +23,8 @@ global using Atc.Dsc.Configurations.Cli.Extensions;
 global using Atc.Dsc.Configurations.Cli.Parsers;
 global using Atc.Dsc.Configurations.Cli.Repositories;
 global using Atc.Dsc.Configurations.Cli.Tui;
+global using Atc.Dsc.Configurations.Cli.Tui.Theme;
+global using Atc.Dsc.Configurations.Cli.Tui.Views;
 global using CliWrap;
 global using CliWrap.Buffered;
 global using Microsoft.Extensions.Configuration;

--- a/src/Atc.Dsc.Configurations.Cli/Program.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Program.cs
@@ -96,6 +96,7 @@ public static class Program
         });
 
         serviceCollection.AddSingleton<IProfileRepository>(sp => sp.GetRequiredService<CachingProfileRepository>());
+        serviceCollection.AddSingleton<IExecutionHistoryService, ExecutionHistoryService>();
     }
 
     private static void CleanupTempFiles()

--- a/src/Atc.Dsc.Configurations.Cli/Repositories/CachingProfileRepository.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Repositories/CachingProfileRepository.cs
@@ -52,12 +52,27 @@ public sealed class CachingProfileRepository : IProfileRepository, IDisposable
                 }
             }
 
-            var result = await inner.ListProfilesAsync(cancellationToken);
-            var json = JsonSerializer.Serialize(result, jsonOptions);
+            try
+            {
+                var result = await inner.ListProfilesAsync(cancellationToken);
+                var json = JsonSerializer.Serialize(result, jsonOptions);
+                await File.WriteAllTextAsync(indexPath, json, cancellationToken);
+                return result;
+            }
+            catch (HttpRequestException)
+            {
+                if (File.Exists(indexPath))
+                {
+                    var stale = await File.ReadAllTextAsync(indexPath, cancellationToken);
+                    var profiles = JsonSerializer.Deserialize<List<ProfileSummary>>(stale, jsonOptions);
+                    if (profiles is not null)
+                    {
+                        return profiles;
+                    }
+                }
 
-            await File.WriteAllTextAsync(indexPath, json, cancellationToken);
-
-            return result;
+                throw;
+            }
         }
         finally
         {
@@ -87,7 +102,10 @@ public sealed class CachingProfileRepository : IProfileRepository, IDisposable
             }
 
             var content = await inner.GetProfileContentAsync(fileName, cancellationToken);
-            await File.WriteAllTextAsync(cachedPath, content, cancellationToken);
+            if (content.Length > 0)
+            {
+                await File.WriteAllTextAsync(cachedPath, content, cancellationToken);
+            }
 
             return content;
         }

--- a/src/Atc.Dsc.Configurations.Cli/Repositories/GitHubProfileRepository.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Repositories/GitHubProfileRepository.cs
@@ -57,12 +57,21 @@ public sealed class GitHubProfileRepository : IProfileRepository
         return profiles;
     }
 
-    public Task<string> GetProfileContentAsync(
+    public async Task<string> GetProfileContentAsync(
         string fileName,
         CancellationToken cancellationToken = default)
     {
         var url = $"https://raw.githubusercontent.com/{owner}/{repo}/{gitRef}/{ConfigurationsPath}/{fileName}";
-        return httpClient.GetStringAsync(new Uri(url), cancellationToken);
+        using var response = await httpClient.GetAsync(
+            new Uri(url),
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return string.Empty;
+        }
+
+        return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 
     public void InvalidateCache()

--- a/src/Atc.Dsc.Configurations.Cli/Services/ExecutionHistoryService.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Services/ExecutionHistoryService.cs
@@ -1,0 +1,137 @@
+namespace Atc.Dsc.Configurations.Cli.Services;
+
+/// <summary>
+/// Persists execution history to <c>~/.atc-dsc/history.json</c>.
+/// Entries are capped at <see cref="MaxEntries"/> to prevent unbounded growth.
+/// </summary>
+public sealed class ExecutionHistoryService : IExecutionHistoryService, IDisposable
+{
+    internal const int MaxEntries = 500;
+
+    private static readonly string DefaultHistoryDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".atc-dsc");
+
+    private readonly string historyDir;
+    private readonly string historyPath;
+    private readonly List<HistoryEntry> entries;
+    private readonly JsonSerializerOptions jsonOptions;
+    private readonly SemaphoreSlim semaphore = new(1, 1);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutionHistoryService"/> class.
+    /// Loads existing history from disk synchronously.
+    /// </summary>
+    /// <param name="jsonOptions">the JSON serializer options.</param>
+    public ExecutionHistoryService(JsonSerializerOptions jsonOptions)
+        : this(jsonOptions, DefaultHistoryDir)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutionHistoryService"/> class
+    /// with a custom history directory (used for testing).
+    /// </summary>
+    /// <param name="jsonOptions">the JSON serializer options.</param>
+    /// <param name="historyDir">the directory for the history file.</param>
+    internal ExecutionHistoryService(
+        JsonSerializerOptions jsonOptions,
+        string historyDir)
+    {
+        this.jsonOptions = jsonOptions;
+        this.historyDir = historyDir;
+        historyPath = Path.Combine(historyDir, "history.json");
+        entries = LoadFromDisk();
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<HistoryEntry> GetAll()
+        => entries.AsReadOnly();
+
+    /// <inheritdoc />
+    public HistoryEntry? GetLatest(string fileName)
+    {
+        for (var i = entries.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(entries[i].FileName, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return entries[i];
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(
+        ExecutionResult result,
+        string fileName)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var passed = result.Results.Count(r => r.State is ResourceState.Compliant or ResourceState.Changed or ResourceState.Executed or ResourceState.Skipped);
+        var failed = result.Results.Count(r => r.State == ResourceState.Failed);
+
+        var entry = new HistoryEntry(
+            result.ProfileName,
+            fileName,
+            result.Mode,
+            result.Success,
+            result.Results.Count,
+            passed,
+            failed,
+            result.Duration.TotalSeconds,
+            DateTimeOffset.UtcNow);
+
+        await semaphore.WaitAsync();
+        try
+        {
+            entries.Add(entry);
+            TrimEntries();
+            await SaveToDiskAsync();
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
+    private void TrimEntries()
+    {
+        if (entries.Count > MaxEntries)
+        {
+            entries.RemoveRange(0, entries.Count - MaxEntries);
+        }
+    }
+
+    private List<HistoryEntry> LoadFromDisk()
+    {
+        if (!File.Exists(historyPath))
+        {
+            return [];
+        }
+
+        try
+        {
+            var json = File.ReadAllText(historyPath);
+            return JsonSerializer.Deserialize<List<HistoryEntry>>(json, jsonOptions) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        semaphore.Dispose();
+    }
+
+    private Task SaveToDiskAsync()
+    {
+        Directory.CreateDirectory(historyDir);
+        var json = JsonSerializer.Serialize(entries, jsonOptions);
+        return File.WriteAllTextAsync(historyPath, json);
+    }
+}

--- a/src/Atc.Dsc.Configurations.Cli/Services/IExecutionHistoryService.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Services/IExecutionHistoryService.cs
@@ -1,0 +1,30 @@
+namespace Atc.Dsc.Configurations.Cli.Services;
+
+/// <summary>
+/// Persists and queries execution history entries.
+/// </summary>
+public interface IExecutionHistoryService
+{
+    /// <summary>
+    /// Gets all history entries, most recent first.
+    /// </summary>
+    /// <returns>A read-only list of all entries.</returns>
+    IReadOnlyList<HistoryEntry> GetAll();
+
+    /// <summary>
+    /// Gets the most recent entry for a given profile file name.
+    /// </summary>
+    /// <param name="fileName">the profile file name.</param>
+    /// <returns>The latest entry, or <see langword="null"/> if none exists.</returns>
+    HistoryEntry? GetLatest(string fileName);
+
+    /// <summary>
+    /// Records an execution result to history.
+    /// </summary>
+    /// <param name="result">the execution result.</param>
+    /// <param name="fileName">the profile file name.</param>
+    /// <returns>A task representing the async save operation.</returns>
+    Task RecordAsync(
+        ExecutionResult result,
+        string fileName);
+}

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ColoredOutputView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ColoredOutputView.cs
@@ -25,6 +25,13 @@ public sealed class ColoredOutputView : View
     }
 
     /// <summary>
+    /// Returns a snapshot of all lines and their color attributes.
+    /// </summary>
+    /// <returns>A read-only list of text/attribute pairs.</returns>
+    public IReadOnlyList<(string Text, Terminal.Gui.Drawing.Attribute Attr)> GetLines()
+        => lines.ToList();
+
+    /// <summary>
     /// Removes all lines and resets the view.
     /// </summary>
     public void Clear()

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ColoredOutputView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ColoredOutputView.cs
@@ -25,6 +25,15 @@ public sealed class ColoredOutputView : View
     }
 
     /// <summary>
+    /// Removes all lines and resets the view.
+    /// </summary>
+    public void Clear()
+    {
+        lines.Clear();
+        UpdateContentSize();
+    }
+
+    /// <summary>
     /// Scrolls the view to show the last line of output.
     /// </summary>
     public void ScrollToEnd()

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ColoredOutputView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ColoredOutputView.cs
@@ -7,7 +7,7 @@ namespace Atc.Dsc.Configurations.Cli.Tui;
 /// </summary>
 public sealed class ColoredOutputView : View
 {
-    private static readonly Terminal.Gui.Drawing.Attribute BgAttr = new(ColorName16.Gray, ColorName16.Black);
+    private static Terminal.Gui.Drawing.Attribute BgAttr => DarkTheme.Default;
 
     private readonly List<(string Text, Terminal.Gui.Drawing.Attribute Attr)> lines = [];
 

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
@@ -19,14 +19,27 @@ public sealed class ExecutionDialog : Dialog
     private readonly Button closeButton;
     private CancellationTokenSource? cts;
 
-    // Color palette
-    private static readonly Terminal.Gui.Drawing.Attribute DefaultAttr = new(ColorName16.Gray, ColorName16.Black);
-    private static readonly Terminal.Gui.Drawing.Attribute HeaderAttr = new(ColorName16.White, ColorName16.Black);
-    private static readonly Terminal.Gui.Drawing.Attribute GreenAttr = new(ColorName16.BrightGreen, ColorName16.Black);
-    private static readonly Terminal.Gui.Drawing.Attribute RedAttr = new(ColorName16.BrightRed, ColorName16.Black);
-    private static readonly Terminal.Gui.Drawing.Attribute YellowAttr = new(ColorName16.BrightYellow, ColorName16.Black);
-    private static readonly Terminal.Gui.Drawing.Attribute CyanAttr = new(ColorName16.BrightCyan, ColorName16.Black);
-    private static readonly Terminal.Gui.Drawing.Attribute DimAttr = new(ColorName16.DarkGray, ColorName16.Black);
+    // Color palette — sourced from the centralized DarkTheme
+    private static Terminal.Gui.Drawing.Attribute DefaultAttr
+        => DarkTheme.Default;
+
+    private static Terminal.Gui.Drawing.Attribute HeaderAttr
+        => DarkTheme.Header;
+
+    private static Terminal.Gui.Drawing.Attribute GreenAttr
+        => DarkTheme.Green;
+
+    private static Terminal.Gui.Drawing.Attribute RedAttr
+        => DarkTheme.Red;
+
+    private static Terminal.Gui.Drawing.Attribute YellowAttr
+        => DarkTheme.Yellow;
+
+    private static Terminal.Gui.Drawing.Attribute CyanAttr
+        => DarkTheme.Cyan;
+
+    private static Terminal.Gui.Drawing.Attribute DimAttr
+        => DarkTheme.Dim;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExecutionDialog"/> class.
@@ -58,7 +71,6 @@ public sealed class ExecutionDialog : Dialog
         Title = $"{modeTitle} {profiles.Count} profile(s)";
         Width = Dim.Percent(90);
         Height = Dim.Percent(85);
-
         progressLabel = new Label
         {
             X = 0,

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
@@ -4,6 +4,7 @@ namespace Atc.Dsc.Configurations.Cli.Tui;
 /// Modal dialog that runs DSC test/apply operations using the structured
 /// <see cref="IDscClient"/> and renders colored, formatted per-resource
 /// results with status symbols, durations, and a final summary.
+/// Shows a queue sidebar when executing multiple profiles.
 /// </summary>
 [SuppressMessage("Reliability", "CA2213:Disposable fields should be disposed", Justification = "Terminal.Gui manages child view disposal")]
 public sealed class ExecutionDialog : Dialog
@@ -16,6 +17,7 @@ public sealed class ExecutionDialog : Dialog
 
     private readonly ColoredOutputView outputView;
     private readonly LoadingSpinnerView progressSpinner;
+    private readonly ProfileQueueView? queueView;
     private readonly Button closeButton;
     private CancellationTokenSource? cts;
 
@@ -69,41 +71,24 @@ public sealed class ExecutionDialog : Dialog
 
         var modeTitle = mode == ExecutionMode.Test ? "Testing" : "Applying";
         Title = $"{modeTitle} {profiles.Count} profile(s)";
-        Width = Dim.Percent(90);
+        Width = Dim.Percent(95);
         Height = Dim.Percent(85);
-        progressSpinner = new LoadingSpinnerView(app)
-        {
-            X = 0,
-            Y = 0,
-            Width = Dim.Fill(),
-            Height = 1,
-            Label = "Starting...",
-        };
 
-        outputView = new ColoredOutputView
-        {
-            X = 0,
-            Y = 1,
-            Width = Dim.Fill(),
-            Height = Dim.Fill(1),
-            CanFocus = true,
-        };
+        progressSpinner = CreateSpinner(app);
+        outputView = CreateOutputView(profiles.Count > 1);
+        closeButton = CreateCloseButton();
 
-        closeButton = new Button
+        if (profiles.Count > 1)
         {
-            Text = "Cancel",
-            IsDefault = true,
-        };
-        closeButton.Accepting += (_, e) =>
+            queueView = CreateQueueView(app, profiles);
+            Add(progressSpinner, queueView, outputView);
+        }
+        else
         {
-            cts?.Cancel();
-            this.app.RequestStop();
-            e.Handled = true;
-        };
+            Add(progressSpinner, outputView);
+        }
 
-        Add(progressSpinner, outputView);
         AddButton(closeButton);
-
         Initialized += (_, _) => _ = RunExecutionAsync();
     }
 
@@ -114,6 +99,63 @@ public sealed class ExecutionDialog : Dialog
     /// <returns>A read-only list of text/attribute pairs from the output view.</returns>
     internal IReadOnlyList<(string Text, Terminal.Gui.Drawing.Attribute Attr)> GetOutputLines()
         => outputView.GetLines();
+
+    private static LoadingSpinnerView CreateSpinner(IApplication app)
+        => new(app)
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = 1,
+            Label = "Starting...",
+        };
+
+    private static ColoredOutputView CreateOutputView(bool hasQueue)
+    {
+        var x = hasQueue ? Pos.Percent(25) : Pos.Absolute(0);
+
+        return new ColoredOutputView
+        {
+            X = x,
+            Y = 1,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            CanFocus = true,
+        };
+    }
+
+    private static ProfileQueueView CreateQueueView(
+        IApplication app,
+        IReadOnlyList<ProfileSummary> profiles)
+    {
+        var view = new ProfileQueueView(app)
+        {
+            X = 0,
+            Y = 1,
+            Width = Dim.Percent(25),
+            Height = Dim.Fill(1),
+        };
+
+        view.SetProfiles(profiles);
+        return view;
+    }
+
+    private Button CreateCloseButton()
+    {
+        var button = new Button
+        {
+            Text = "Cancel",
+            IsDefault = true,
+        };
+        button.Accepting += (_, e) =>
+        {
+            cts?.Cancel();
+            app.RequestStop();
+            e.Handled = true;
+        };
+
+        return button;
+    }
 
     private async Task RunExecutionAsync()
     {
@@ -149,6 +191,7 @@ public sealed class ExecutionDialog : Dialog
         finally
         {
             progressSpinner.Stop();
+            queueView?.StopSpinner();
             cts = null;
         }
 
@@ -175,10 +218,19 @@ public sealed class ExecutionDialog : Dialog
 
             var profile = profiles[i];
             RenderProfileHeader(profile, i);
+            queueView?.UpdateStatus(i, QueueItemStatus.Running);
 
             try
             {
-                var success = await ExecuteSingleProfileAsync(client, profile, cancellationToken);
+                var success = await ExecuteSingleProfileAsync(
+                    client,
+                    profile,
+                    cancellationToken);
+
+                queueView?.UpdateStatus(
+                    i,
+                    success ? QueueItemStatus.Passed : QueueItemStatus.Failed);
+
                 if (success)
                 {
                     passed++;
@@ -255,7 +307,8 @@ public sealed class ExecutionDialog : Dialog
             summaryAttr);
         FlushOutput();
 
-        UpdateProgress($"Done: {passed} passed, {failed} failed ({elapsed.TotalSeconds:F1}s)");
+        UpdateProgress(
+            $"Done: {passed} passed, {failed} failed ({elapsed.TotalSeconds:F1}s)");
     }
 
     private void RenderResults(ExecutionResult result)
@@ -271,7 +324,9 @@ public sealed class ExecutionDialog : Dialog
                 ?? res.State
                     .ToString()
                     .ToLowerInvariant();
-            var nameCol = res.Name.Length > 35 ? res.Name[..32] + "..." : res.Name;
+            var nameCol = res.Name.Length > 35
+                ? res.Name[..32] + "..."
+                : res.Name;
             var statusCol = $"({statusText})";
 
             AppendLine(
@@ -287,7 +342,9 @@ public sealed class ExecutionDialog : Dialog
         // Profile summary line
         var resultLabel = result.Success ? "PASS" : "FAIL";
         var resultAttr = result.Success ? GreenAttr : RedAttr;
-        AppendLine($"  Duration: {result.Duration.TotalSeconds:F1}s | Result: {resultLabel}", resultAttr);
+        AppendLine(
+            $"  Duration: {result.Duration.TotalSeconds:F1}s | Result: {resultLabel}",
+            resultAttr);
     }
 
     private static (string Symbol, Terminal.Gui.Drawing.Attribute Attr) GetSymbolAndColor(

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
@@ -15,7 +15,7 @@ public sealed class ExecutionDialog : Dialog
     private readonly ExecutionMode mode;
 
     private readonly ColoredOutputView outputView;
-    private readonly Label progressLabel;
+    private readonly LoadingSpinnerView progressSpinner;
     private readonly Button closeButton;
     private CancellationTokenSource? cts;
 
@@ -71,12 +71,13 @@ public sealed class ExecutionDialog : Dialog
         Title = $"{modeTitle} {profiles.Count} profile(s)";
         Width = Dim.Percent(90);
         Height = Dim.Percent(85);
-        progressLabel = new Label
+        progressSpinner = new LoadingSpinnerView(app)
         {
             X = 0,
             Y = 0,
             Width = Dim.Fill(),
-            Text = "Starting...",
+            Height = 1,
+            Label = "Starting...",
         };
 
         outputView = new ColoredOutputView
@@ -100,7 +101,7 @@ public sealed class ExecutionDialog : Dialog
             e.Handled = true;
         };
 
-        Add(progressLabel, outputView);
+        Add(progressSpinner, outputView);
         AddButton(closeButton);
 
         Initialized += (_, _) => _ = RunExecutionAsync();
@@ -111,6 +112,7 @@ public sealed class ExecutionDialog : Dialog
         using var tokenSource = new CancellationTokenSource();
         cts = tokenSource;
 
+        progressSpinner.Start();
         var sw = Stopwatch.StartNew();
 
         try
@@ -138,6 +140,7 @@ public sealed class ExecutionDialog : Dialog
         }
         finally
         {
+            progressSpinner.Stop();
             cts = null;
         }
 
@@ -296,7 +299,8 @@ public sealed class ExecutionDialog : Dialog
     {
         app.Invoke(() =>
         {
-            progressLabel.Text = text;
+            progressSpinner.Label = text;
+            progressSpinner.SetNeedsDraw();
         });
     }
 

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
@@ -19,6 +19,7 @@ public sealed class ExecutionDialog : Dialog
     private readonly LoadingSpinnerView progressSpinner;
     private readonly ProfileQueueView? queueView;
     private readonly Button closeButton;
+    private readonly List<(string FileName, ExecutionResult Result)> collectedResults = [];
     private CancellationTokenSource? cts;
 
     // Color palette — sourced from the centralized DarkTheme
@@ -99,6 +100,13 @@ public sealed class ExecutionDialog : Dialog
     /// <returns>A read-only list of text/attribute pairs from the output view.</returns>
     internal IReadOnlyList<(string Text, Terminal.Gui.Drawing.Attribute Attr)> GetOutputLines()
         => outputView.GetLines();
+
+    /// <summary>
+    /// Gets the collected execution results for history recording.
+    /// </summary>
+    /// <returns>A list of file name and result pairs.</returns>
+    internal IReadOnlyList<(string FileName, ExecutionResult Result)> GetResults()
+        => collectedResults;
 
     private static LoadingSpinnerView CreateSpinner(IApplication app)
         => new(app)
@@ -285,6 +293,7 @@ public sealed class ExecutionDialog : Dialog
                 : await client.ApplyAsync(tempPath, cancellationToken);
 
             RenderResults(result);
+            collectedResults.Add((profile.FileName, result));
 
             return result.Success;
         }

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ExecutionDialog.cs
@@ -107,6 +107,14 @@ public sealed class ExecutionDialog : Dialog
         Initialized += (_, _) => _ = RunExecutionAsync();
     }
 
+    /// <summary>
+    /// Gets the output lines after execution completes. Used by the
+    /// execution log tab to capture results from this session.
+    /// </summary>
+    /// <returns>A read-only list of text/attribute pairs from the output view.</returns>
+    internal IReadOnlyList<(string Text, Terminal.Gui.Drawing.Attribute Attr)> GetOutputLines()
+        => outputView.GetLines();
+
     private async Task RunExecutionAsync()
     {
         using var tokenSource = new CancellationTokenSource();

--- a/src/Atc.Dsc.Configurations.Cli/Tui/ExtensionLoader.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/ExtensionLoader.cs
@@ -6,6 +6,8 @@ namespace Atc.Dsc.Configurations.Cli.Tui;
 /// </summary>
 internal sealed class ExtensionLoader(IProfileRepository repository)
 {
+    private readonly HashSet<string> notFoundFiles = new(StringComparer.OrdinalIgnoreCase);
+
     internal async Task<string> LoadAsync(string profileFileName)
     {
         var baseName = profileFileName.Replace(
@@ -42,55 +44,69 @@ internal sealed class ExtensionLoader(IProfileRepository repository)
         string idField,
         string labelField)
     {
-        try
-        {
-            var json = await repository.GetProfileContentAsync(fileName);
-            using var doc = JsonDocument.Parse(json);
-
-            if (!doc.RootElement.TryGetProperty("extensions", out var arr) ||
-                arr.ValueKind != JsonValueKind.Array)
-            {
-                return 0;
-            }
-
-            var count = arr.GetArrayLength();
-            if (count == 0)
-            {
-                return 0;
-            }
-
-            if (sb.Length > 0)
-            {
-                sb.AppendLine();
-            }
-
-            sb.Append(' ');
-            sb.Append(heading);
-            sb.Append(" (");
-            sb.Append(count);
-            sb.AppendLine(")");
-            sb.AppendLine(" " + new string('\u2500', 50));
-
-            foreach (var ext in arr.EnumerateArray())
-            {
-                var id = ext.TryGetProperty(idField, out var n) ? n.GetString() ?? "?" : "?";
-                var label = ext.TryGetProperty(labelField, out var d) ? d.GetString() : null;
-
-                sb.Append("   ");
-                sb.AppendLine(id);
-
-                if (label is not null)
-                {
-                    sb.Append("     ");
-                    sb.AppendLine(label);
-                }
-            }
-
-            return count;
-        }
-        catch (Exception ex) when (ex is HttpRequestException or FileNotFoundException or DirectoryNotFoundException)
+        if (notFoundFiles.Contains(fileName))
         {
             return 0;
         }
+
+        var json = await repository.GetProfileContentAsync(fileName);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            notFoundFiles.Add(fileName);
+            return 0;
+        }
+
+        return RenderExtensions(sb, json, heading, idField, labelField);
+    }
+
+    private static int RenderExtensions(
+        StringBuilder sb,
+        string json,
+        string heading,
+        string idField,
+        string labelField)
+    {
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("extensions", out var arr) ||
+            arr.ValueKind != JsonValueKind.Array)
+        {
+            return 0;
+        }
+
+        var count = arr.GetArrayLength();
+        if (count == 0)
+        {
+            return 0;
+        }
+
+        if (sb.Length > 0)
+        {
+            sb.AppendLine();
+        }
+
+        sb.Append(' ');
+        sb.Append(heading);
+        sb.Append(" (");
+        sb.Append(count);
+        sb.AppendLine(")");
+        sb.AppendLine(" " + new string('\u2500', 50));
+
+        foreach (var ext in arr.EnumerateArray())
+        {
+            var id = ext.TryGetProperty(idField, out var n) ? n.GetString() ?? "?" : "?";
+            var label = ext.TryGetProperty(labelField, out var d) ? d.GetString() : null;
+
+            sb.Append("   ");
+            sb.AppendLine(id);
+
+            if (label is not null)
+            {
+                sb.Append("     ");
+                sb.AppendLine(label);
+            }
+        }
+
+        return count;
     }
 }

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -208,7 +208,6 @@ public sealed class MainWindow : Window
             if (summaries.Count > 0)
             {
                 profileList.SelectedItem = 0;
-                await LoadProfileDetailAsync(0);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -20,7 +20,7 @@ public sealed class MainWindow : Window
     private readonly TabView detailTabs;
     private readonly TopTabBarView topTabBar;
     private readonly ColoredOutputView overviewText;
-    private readonly TextView resourcesText;
+    private readonly ColoredOutputView resourcesText;
     private readonly TextView extensionsText;
     private readonly TextView rawYamlText;
     private readonly TextField filterField;
@@ -73,7 +73,10 @@ public sealed class MainWindow : Window
         profileList = CreateProfileList();
         filterField = CreateFilterField();
         overviewText = CreateOverviewView();
-        resourcesText = CreateReadOnlyTextView(wordWrap: false);
+        resourcesText = new ColoredOutputView
+        {
+            X = 0, Y = 0, Width = Dim.Fill(), Height = Dim.Fill(), CanFocus = false,
+        };
         extensionsText = CreateReadOnlyTextView(wordWrap: false);
         rawYamlText = CreateReadOnlyTextView(wordWrap: false);
         detailTabs = CreateDetailTabs();
@@ -852,47 +855,44 @@ public sealed class MainWindow : Window
 
     private void PopulateResourcesTab(Contracts.Profile profile)
     {
-        const string rowFmt = " {0,2}  {1,-37} {2,-13} {3}";
+        resourcesText.Clear();
+
         var resList = profile.Resources;
-        var sb = new StringBuilder();
-        sb.AppendLine(string.Format(
-            CultureInfo.InvariantCulture,
-            rowFmt,
-            "#",
-            "Name",
-            "Type",
-            "Depends on"));
-        sb.AppendLine(" " + new string('\u2500', 66));
+
+        resourcesText.AppendLine(
+            $" {"#",2}  {"Name",-37} {"Type",-13}",
+            DarkTheme.Header);
+        resourcesText.AppendLine(
+            " " + new string('\u2500', 54),
+            DarkTheme.Dim);
 
         for (var i = 0; i < resList.Count; i++)
         {
-            var res = resList[i];
-            var name = res.Name.Length > 37 ? res.Name[..36] + "." : res.Name;
-            var type = AbbreviateType(res.Type);
-            var dependsOn = string.Empty;
-
-            if (res.DependsOn.Count > 0)
-            {
-                var indices = new List<string>();
-                foreach (var dep in res.DependsOn)
-                {
-                    var idx = ResolveDependencyIndex(dep, resList);
-                    indices.Add(idx.HasValue ? $"#{idx.Value}" : "?");
-                }
-
-                dependsOn = "<- " + string.Join(", ", indices);
-            }
-
-            sb.AppendLine(string.Format(
-                CultureInfo.InvariantCulture,
-                rowFmt,
-                i + 1,
-                name,
-                type,
-                dependsOn));
+            AppendResourceRow(resList, i);
         }
+    }
 
-        resourcesText.Text = sb.ToString();
+    private void AppendResourceRow(
+        IReadOnlyList<Resource> resList,
+        int index)
+    {
+        var res = resList[index];
+        var name = res.Name.Length > 37 ? res.Name[..36] + "." : res.Name;
+        var type = AbbreviateType(res.Type);
+        var typeAttr = GetTypeColor(type);
+
+        resourcesText.AppendLine(
+            $" {index + 1,2}  {name,-37} {type,-13}",
+            typeAttr);
+
+        foreach (var dep in res.DependsOn)
+        {
+            var idx = ResolveDependencyIndex(dep, resList);
+            var depName = idx.HasValue ? resList[idx.Value - 1].Name : "?";
+            resourcesText.AppendLine(
+                $"      \u2514\u2500 depends on: {depName} (#{idx?.ToString(CultureInfo.InvariantCulture) ?? "?"})",
+                DarkTheme.Dim);
+        }
     }
 
     private Task ExecuteSelectedAsync(ExecutionMode executionMode)

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -22,7 +22,7 @@ public sealed class MainWindow : Window
     private readonly TextView extensionsText;
     private readonly TextView rawYamlText;
     private readonly TextField filterField;
-    private readonly Label statusLabel;
+    private readonly ActionHintsView actionHints;
 
     private readonly ObservableCollection<string> profileDisplayNames = [];
     private readonly List<ProfileSummary> allProfileSummaries = [];
@@ -70,9 +70,9 @@ public sealed class MainWindow : Window
         detailTabs = CreateDetailTabs();
         var rightPanel = CreateRightPanel(leftPanel);
 
-        statusLabel = CreateStatusLabel();
+        actionHints = CreateActionHints();
 
-        Add(leftPanel, rightPanel, statusLabel);
+        Add(leftPanel, rightPanel, actionHints);
         AddKeyBindings();
 
         // Load profiles once the UI is ready
@@ -91,6 +91,8 @@ public sealed class MainWindow : Window
             MarkMultiple = true,
             CanFocus = true,
         };
+
+        list.SetScheme(DarkTheme.CreateListScheme());
 
         list.ValueChanged += OnProfileSelectionChanged;
         return list;
@@ -170,15 +172,19 @@ public sealed class MainWindow : Window
         return rightPanel;
     }
 
-    private Label CreateStatusLabel()
-        => new()
+    private ActionHintsView CreateActionHints()
+    {
+        var view = new ActionHintsView
         {
             X = 0,
             Y = Pos.AnchorEnd(1),
             Width = Dim.Fill(),
             Height = 1,
-            Text = BuildStatusText(),
         };
+
+        view.SetHints(BuildActionHints());
+        return view;
+    }
 
     private async Task LoadProfilesAsync()
     {
@@ -399,28 +405,48 @@ public sealed class MainWindow : Window
     {
         profileList.MarkAll(selected);
         profileList.SetNeedsLayout();
-        UpdateStatusLabel();
+        UpdateActionHints();
     }
 
-    private void UpdateStatusLabel()
+    private void UpdateActionHints()
     {
-        var left = BuildStatusText();
-        const string right = "[j/k] Scroll  [Tab] Switch ";
-        var width = statusLabel.Frame.Width;
-        var padding = width - left.Length - right.Length;
-        statusLabel.Text = padding > 0
-            ? left + new string(' ', padding) + right
-            : left;
+        actionHints.SetHints(BuildActionHints());
     }
 
-    private string BuildStatusText()
+    private List<ActionHint> BuildActionHints()
     {
+        var txt = DarkTheme.StatusBarKey;
+
+        var list = new List<ActionHint>
+        {
+            new("Space", "Toggle", txt, txt),
+            new("^a", "All", txt, txt),
+            new("^d", "None", txt, txt),
+            new("t", "Test", txt, txt),
+        };
+
+        if (envInfo.IsAdmin)
+        {
+            list.Add(new ActionHint("Enter", "Apply", txt, txt));
+        }
+
+        list.Add(new ActionHint("/", "Filter", txt, txt));
+        list.Add(new ActionHint("?", "Help", txt, txt));
+        list.Add(new ActionHint("q", "Quit", txt, txt));
+
         var marked = profileList.GetAllMarkedItems();
         var count = marked.Count();
-        var suffix = count > 0 ? $"  ({count} selected)" : string.Empty;
-        return envInfo.IsAdmin
-            ? $" [Space] Toggle  [Ctrl+a] All  [Ctrl+d] None  [Enter] Apply  [t] Test  [/] Filter  [?] Help  [q] Quit{suffix}"
-            : $" [Space] Toggle  [Ctrl+a] All  [Ctrl+d] None  [t] Test  [/] Filter  [?] Help  [q] Quit{suffix}  (not admin \u2014 test only)";
+        if (count > 0)
+        {
+            list.Add(new ActionHint($"{count}", "selected", DarkTheme.StatusBarHighlight, txt));
+        }
+
+        if (!envInfo.IsAdmin)
+        {
+            list.Add(new ActionHint("\u2014", "test only", txt, txt));
+        }
+
+        return list;
     }
 
     private void OnProfileSelectionChanged(
@@ -433,7 +459,7 @@ public sealed class MainWindow : Window
             return;
         }
 
-        UpdateStatusLabel();
+        UpdateActionHints();
 
         _ = RunGuardedAsync(() => LoadProfileDetailAsync(filteredIndices[index.Value]));
     }

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -172,7 +172,7 @@ public sealed class MainWindow : Window
             Title = "Profiles",
             X = 0,
             Y = 0,
-            Width = Dim.Percent(40),
+            Width = Dim.Percent(28),
             Height = Dim.Fill(),
         };
 
@@ -318,7 +318,7 @@ public sealed class MainWindow : Window
     }
 
     private static TopTabBarView CreateTopTabBar()
-        => new(["Profiles", "Execution Log", "Environment"])
+        => new(["Profiles/Configurations", "Execution Log", "Environment"])
         {
             X = 0,
             Y = 0,
@@ -372,7 +372,7 @@ public sealed class MainWindow : Window
 
             for (var i = 0; i < summaries.Count; i++)
             {
-                profileDisplayNames.Add(summaries[i].Name);
+                profileDisplayNames.Add(StripConfigurationSuffix(summaries[i].Name));
                 filteredIndices.Add(i);
             }
 
@@ -1068,7 +1068,7 @@ public sealed class MainWindow : Window
                 name.Contains(filter, StringComparison.OrdinalIgnoreCase))
             {
                 filteredIndices.Add(i);
-                profileDisplayNames.Add(name);
+                profileDisplayNames.Add(StripConfigurationSuffix(name));
             }
         }
 
@@ -1100,6 +1100,9 @@ public sealed class MainWindow : Window
                 "OK"));
         }
     }
+
+    internal static string StripConfigurationSuffix(string name)
+        => name.Replace(" configuration", string.Empty, StringComparison.OrdinalIgnoreCase);
 
     internal static string AbbreviateType(string type) => type switch
     {

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -17,6 +17,7 @@ public sealed class MainWindow : Window
 
     private readonly ListView profileList;
     private readonly TabView detailTabs;
+    private readonly TopTabBarView topTabBar;
     private readonly ColoredOutputView overviewText;
     private readonly TextView resourcesText;
     private readonly TextView extensionsText;
@@ -24,10 +25,15 @@ public sealed class MainWindow : Window
     private readonly TextField filterField;
     private readonly ActionHintsView actionHints;
     private readonly LoadingSpinnerView spinner;
+    private readonly ColoredOutputView executionLogView;
+    private readonly ColoredOutputView environmentView;
+    private readonly View profilesPage;
 
     private readonly ObservableCollection<string> profileDisplayNames = [];
     private readonly List<ProfileSummary> allProfileSummaries = [];
     private readonly List<int> filteredIndices = [];
+
+    private int activeTopTab;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MainWindow"/> class.
@@ -61,33 +67,24 @@ public sealed class MainWindow : Window
 
         profileList = CreateProfileList();
         filterField = CreateFilterField();
-        var leftPanel = CreateLeftPanel();
-
-        overviewText = new ColoredOutputView
-        {
-            X = 0,
-            Y = 0,
-            Width = Dim.Fill(),
-            Height = Dim.Fill(),
-            CanFocus = false,
-        };
-
+        overviewText = CreateOverviewView();
         resourcesText = CreateReadOnlyTextView(wordWrap: false);
         extensionsText = CreateReadOnlyTextView(wordWrap: false);
         rawYamlText = CreateReadOnlyTextView(wordWrap: false);
         detailTabs = CreateDetailTabs();
-        spinner = new LoadingSpinnerView(app)
-        {
-            X = 1,
-            Y = 1,
-            Width = Dim.Fill(),
-            Height = 1,
-        };
-        var rightPanel = CreateRightPanel(leftPanel);
+        spinner = new LoadingSpinnerView(app) { X = 1, Y = 1, Width = Dim.Fill(), Height = 1 };
 
+        var leftPanel = CreateLeftPanel();
+        var rightPanel = CreateRightPanel(leftPanel);
+        profilesPage = CreateProfilesPage(leftPanel, rightPanel);
+        executionLogView = CreateExecutionLogView();
+        environmentView = CreateEnvironmentView();
+        topTabBar = CreateTopTabBar();
         actionHints = CreateActionHints();
 
-        Add(leftPanel, rightPanel, actionHints);
+        SetupPageLayout();
+        Add(topTabBar, profilesPage, executionLogView, environmentView, actionHints);
+        SwitchTopTab(0);
         AddKeyBindings();
 
         // Load profiles once the UI is ready
@@ -110,6 +107,21 @@ public sealed class MainWindow : Window
         list.SetScheme(DarkTheme.CreateListScheme());
 
         list.ValueChanged += OnProfileSelectionChanged;
+
+        list.KeyDown += (_, key) =>
+        {
+            if (key == Key.CursorLeft || key == Key.CursorRight)
+            {
+                key.Handled = true;
+            }
+            else if (key == Key.Space)
+            {
+                list.MarkUnmarkSelectedItem();
+                UpdateActionHints();
+                key.Handled = true;
+            }
+        };
+
         return list;
     }
 
@@ -128,6 +140,26 @@ public sealed class MainWindow : Window
         return field;
     }
 
+    private static ColoredOutputView CreateOverviewView()
+        => new()
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            CanFocus = false,
+        };
+
+    private void SetupPageLayout()
+    {
+        profilesPage.Y = 1;
+        profilesPage.Height = Dim.Fill(1);
+        executionLogView.Y = 1;
+        executionLogView.Height = Dim.Fill(1);
+        environmentView.Y = 1;
+        environmentView.Height = Dim.Fill(1);
+    }
+
     private FrameView CreateLeftPanel()
     {
         var leftPanel = new FrameView
@@ -136,7 +168,7 @@ public sealed class MainWindow : Window
             X = 0,
             Y = 0,
             Width = Dim.Percent(40),
-            Height = Dim.Fill(1),
+            Height = Dim.Fill(),
         };
 
         leftPanel.Add(filterField, profileList);
@@ -181,11 +213,105 @@ public sealed class MainWindow : Window
             X = Pos.Right(leftPanel),
             Y = 0,
             Width = Dim.Fill(),
-            Height = Dim.Fill(1),
+            Height = Dim.Fill(),
         };
 
         rightPanel.Add(detailTabs, spinner);
         return rightPanel;
+    }
+
+    private static View CreateProfilesPage(
+        View leftPanel,
+        View rightPanel)
+    {
+        var page = new View
+        {
+            X = 0,
+            Width = Dim.Fill(),
+            CanFocus = true,
+        };
+
+        page.Add(leftPanel, rightPanel);
+        return page;
+    }
+
+    private static ColoredOutputView CreateExecutionLogView()
+    {
+        var view = new ColoredOutputView
+        {
+            X = 0,
+            Width = Dim.Fill(),
+            CanFocus = true,
+        };
+
+        view.AppendLine("No executions yet.", DarkTheme.Dim);
+        return view;
+    }
+
+    private ColoredOutputView CreateEnvironmentView()
+    {
+        var view = new ColoredOutputView
+        {
+            X = 0,
+            Width = Dim.Fill(),
+            CanFocus = true,
+        };
+
+        PopulateEnvironmentView(view);
+        return view;
+    }
+
+    private void PopulateEnvironmentView(ColoredOutputView view)
+    {
+        view.Clear();
+
+        view.AppendLine("Environment", DarkTheme.Header);
+        view.AppendLine(new string('\u2500', 40), DarkTheme.Dim);
+        view.AppendLine(string.Empty, DarkTheme.Default);
+
+        var adminLabel = envInfo.IsAdmin ? "Yes" : "No";
+        var adminAttr = envInfo.IsAdmin ? DarkTheme.Green : DarkTheme.Yellow;
+        view.AppendLine($"  Admin:           {adminLabel}", adminAttr);
+
+        var dscLabel = envInfo.DscCliAvailable
+            ? envInfo.DscCliVersion ?? "available"
+            : "not found";
+        var dscAttr = envInfo.DscCliAvailable ? DarkTheme.Green : DarkTheme.Red;
+        view.AppendLine($"  DSC CLI:         {dscLabel}", dscAttr);
+
+        view.AppendLine(
+            $"  OS:              {Environment.OSVersion}",
+            DarkTheme.Default);
+        view.AppendLine(
+            $"  .NET Runtime:    {Environment.Version}",
+            DarkTheme.Default);
+        view.AppendLine(string.Empty, DarkTheme.Default);
+    }
+
+    private static TopTabBarView CreateTopTabBar()
+        => new(["Profiles", "Execution Log", "Environment"])
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = 1,
+        };
+
+    private void SwitchTopTab(int index)
+    {
+        activeTopTab = index;
+
+        profilesPage.Visible = index == 0;
+        executionLogView.Visible = index == 1;
+        environmentView.Visible = index == 2;
+
+        topTabBar.SetActive(index);
+        UpdateActionHints();
+
+        if (index == 0)
+        {
+            profileList.SetFocus();
+        }
     }
 
     private ActionHintsView CreateActionHints()
@@ -263,6 +389,14 @@ public sealed class MainWindow : Window
                 return;
             }
 
+            // Tab key — handle globally before TabView can intercept it
+            if (key == Key.Tab && IsProfilesTabActive())
+            {
+                HandleTabKey();
+                key.Handled = true;
+                return;
+            }
+
             if (filterField.HasFocus)
             {
                 return;
@@ -274,17 +408,25 @@ public sealed class MainWindow : Window
 
     private void HandleNonFilterKey(Key key)
     {
-        if (key == Key.Q)
+        if (key == Key.D1 || key == Key.D2 || key == Key.D3)
+        {
+            HandleTopTabKey(key);
+            key.Handled = true;
+        }
+        else if (key == Key.Q)
         {
             ConfirmQuit();
             key.Handled = true;
         }
-        else if (key == Key.Tab)
+        else if (IsProfilesTabActive())
         {
-            HandleTabKey();
-            key.Handled = true;
+            HandleProfilesKey(key);
         }
-        else if (key == Key.H)
+    }
+
+    private void HandleProfilesKey(Key key)
+    {
+        if (key == Key.H)
         {
             profileList.SetFocus();
             key.Handled = true;
@@ -319,6 +461,15 @@ public sealed class MainWindow : Window
             HandleActionKeys(key);
         }
     }
+
+    private void HandleTopTabKey(Key key)
+    {
+        var index = key == Key.D1 ? 0 : key == Key.D2 ? 1 : 2;
+        SwitchTopTab(index);
+    }
+
+    private bool IsProfilesTabActive()
+        => activeTopTab == 0;
 
     private void HandleTabKey()
     {
@@ -434,12 +585,23 @@ public sealed class MainWindow : Window
     private List<ActionHint> BuildActionHints()
     {
         var txt = DarkTheme.StatusBarKey;
+        var list = new List<ActionHint>();
 
-        var list = new List<ActionHint>
+        if (IsProfilesTabActive())
         {
-            new("Space", "Toggle", txt, txt),
-            new("t", "Test", txt, txt),
-        };
+            AppendProfileHints(list, txt);
+        }
+
+        list.Add(new ActionHint("q", "Quit", txt, txt));
+        return list;
+    }
+
+    private void AppendProfileHints(
+        List<ActionHint> list,
+        Terminal.Gui.Drawing.Attribute txt)
+    {
+        list.Add(new ActionHint("Space", "Toggle", txt, txt));
+        list.Add(new ActionHint("t", "Test", txt, txt));
 
         if (envInfo.IsAdmin)
         {
@@ -447,7 +609,6 @@ public sealed class MainWindow : Window
         }
 
         list.Add(new ActionHint("?", "Help", txt, txt));
-        list.Add(new ActionHint("q", "Quit", txt, txt));
 
         var marked = profileList.GetAllMarkedItems();
         var count = marked.Count();
@@ -460,8 +621,6 @@ public sealed class MainWindow : Window
         {
             list.Add(new ActionHint("\u2014", "test only", txt, txt));
         }
-
-        return list;
     }
 
     private void OnProfileSelectionChanged(
@@ -677,7 +836,29 @@ public sealed class MainWindow : Window
 
         app.Run(executionDialog);
 
+        CaptureExecutionLog(executionDialog);
+
         return Task.CompletedTask;
+    }
+
+    private void CaptureExecutionLog(ExecutionDialog dialog)
+    {
+        var lines = dialog.GetOutputLines();
+        if (lines.Count == 0)
+        {
+            return;
+        }
+
+        // Clear placeholder text on first real execution
+        if (executionLogView.GetLines().Count == 1)
+        {
+            executionLogView.Clear();
+        }
+
+        foreach (var (text, attr) in lines)
+        {
+            executionLogView.AppendLine(text, attr);
+        }
     }
 
     private bool ConfirmExecution(
@@ -770,7 +951,7 @@ public sealed class MainWindow : Window
 
     private void ApplyFilter()
     {
-        var filter = filterField.Text.Trim() ?? string.Empty;
+        var filter = filterField.Text.Trim();
 
         filteredIndices.Clear();
         profileDisplayNames.Clear();

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -17,7 +17,7 @@ public sealed class MainWindow : Window
 
     private readonly ListView profileList;
     private readonly TabView detailTabs;
-    private readonly TextView overviewText;
+    private readonly ColoredOutputView overviewText;
     private readonly TextView resourcesText;
     private readonly TextView extensionsText;
     private readonly TextView rawYamlText;
@@ -62,7 +62,15 @@ public sealed class MainWindow : Window
         filterField = CreateFilterField();
         var leftPanel = CreateLeftPanel();
 
-        overviewText = CreateReadOnlyTextView(wordWrap: true);
+        overviewText = new ColoredOutputView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            CanFocus = false,
+        };
+
         resourcesText = CreateReadOnlyTextView(wordWrap: false);
         extensionsText = CreateReadOnlyTextView(wordWrap: false);
         rawYamlText = CreateReadOnlyTextView(wordWrap: false);
@@ -212,7 +220,8 @@ public sealed class MainWindow : Window
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            overviewText.Text = $"Error loading profiles: {ex.Message}";
+            overviewText.Clear();
+            overviewText.AppendLine($"Error loading profiles: {ex.Message}", DarkTheme.Red);
         }
     }
 
@@ -481,29 +490,85 @@ public sealed class MainWindow : Window
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            overviewText.Text = $"Error loading profile: {ex.Message}";
+            overviewText.Clear();
+            overviewText.AppendLine($"Error loading profile: {ex.Message}", DarkTheme.Red);
         }
     }
 
     private void PopulateOverviewTab(Contracts.Profile profile)
     {
-        var sb = new StringBuilder();
-        sb.AppendLine(profile.Name);
-        sb.AppendLine(new string('=', profile.Name.Length));
-        sb.AppendLine();
+        overviewText.Clear();
+
+        overviewText.AppendLine(profile.Name, DarkTheme.Header);
+        overviewText.AppendLine(new string('\u2500', profile.Name.Length), DarkTheme.Dim);
+        overviewText.AppendLine(string.Empty, DarkTheme.Default);
 
         if (profile.Description is not null)
         {
-            sb.AppendLine(profile.Description);
-            sb.AppendLine();
+            overviewText.AppendLine(profile.Description, DarkTheme.Default);
+            overviewText.AppendLine(string.Empty, DarkTheme.Default);
         }
 
-        sb.AppendLine(CultureInfo.InvariantCulture, $"Resources: {profile.Resources.Count}");
-        sb.AppendLine(CultureInfo.InvariantCulture, $"File: {profile.FileName}");
-        sb.AppendLine("Source: GitHub");
+        AppendResourceBreakdown(profile.Resources);
 
-        overviewText.Text = sb.ToString();
+        overviewText.AppendLine(string.Empty, DarkTheme.Default);
+        overviewText.AppendLine($"File: {profile.FileName}", DarkTheme.Dim);
+        overviewText.AppendLine("Source: GitHub", DarkTheme.Dim);
     }
+
+    private void AppendResourceBreakdown(IReadOnlyList<Resource> resources)
+    {
+        overviewText.AppendLine(
+            $"Resources ({resources.Count})",
+            DarkTheme.Header);
+
+        var groups = GroupResourcesByType(resources);
+        foreach (var (type, count) in groups)
+        {
+            var attr = GetTypeColor(type);
+            var label = count > 1 ? PluralizeType(type) : type;
+            overviewText.AppendLine($"  \u25a0 {count} {label}", attr);
+        }
+    }
+
+    internal static IReadOnlyList<(string Type, int Count)> GroupResourcesByType(
+        IReadOnlyList<Resource> resources)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var res in resources)
+        {
+            var type = AbbreviateType(res.Type);
+            counts.TryGetValue(type, out var current);
+            counts[type] = current + 1;
+        }
+
+        var result = new List<(string, int)>(counts.Count);
+        foreach (var kvp in counts)
+        {
+            result.Add((kvp.Key, kvp.Value));
+        }
+
+        result.Sort((a, b) => b.Item2.CompareTo(a.Item2));
+        return result;
+    }
+
+    internal static Terminal.Gui.Drawing.Attribute GetTypeColor(
+        string abbreviatedType) => abbreviatedType switch
+    {
+        "Package" => DarkTheme.Green,
+        "Script" => DarkTheme.Cyan,
+        "PowerShell" => DarkTheme.Yellow,
+        "VS Config" => DarkTheme.Blue,
+        "Assertion" => DarkTheme.Dim,
+        _ => DarkTheme.Default,
+    };
+
+    internal static string PluralizeType(string type) => type switch
+    {
+        "PowerShell" => "PowerShell",
+        "VS Config" => "VS Configs",
+        _ => type + "s",
+    };
 
     private void PopulateResourcesTab(Contracts.Profile profile)
     {

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -13,6 +13,7 @@ public sealed class MainWindow : Window
     private readonly IDscClient dscClient;
     private readonly IApplication app;
     private readonly EnvironmentInfo envInfo;
+    private readonly IExecutionHistoryService historyService;
     private readonly ExtensionLoader extensionLoader;
 
     private readonly ListView profileList;
@@ -43,24 +44,28 @@ public sealed class MainWindow : Window
     /// <param name="parser">the profile parser.</param>
     /// <param name="dscClient">the DSC client.</param>
     /// <param name="envInfo">the current environment info.</param>
+    /// <param name="historyService">the execution history service.</param>
     public MainWindow(
         IApplication app,
         IProfileRepository repository,
         IProfileParser parser,
         IDscClient dscClient,
-        EnvironmentInfo envInfo)
+        EnvironmentInfo envInfo,
+        IExecutionHistoryService historyService)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentNullException.ThrowIfNull(repository);
         ArgumentNullException.ThrowIfNull(parser);
         ArgumentNullException.ThrowIfNull(dscClient);
         ArgumentNullException.ThrowIfNull(envInfo);
+        ArgumentNullException.ThrowIfNull(historyService);
 
         this.app = app;
         this.repository = repository;
         this.parser = parser;
         this.dscClient = dscClient;
         this.envInfo = envInfo;
+        this.historyService = historyService;
         extensionLoader = new ExtensionLoader(repository);
 
         Title = "atc-dsc - DSCv3 Configuration Manager";
@@ -235,7 +240,7 @@ public sealed class MainWindow : Window
         return page;
     }
 
-    private static ColoredOutputView CreateExecutionLogView()
+    private ColoredOutputView CreateExecutionLogView()
     {
         var view = new ColoredOutputView
         {
@@ -244,8 +249,32 @@ public sealed class MainWindow : Window
             CanFocus = true,
         };
 
-        view.AppendLine("No executions yet.", DarkTheme.Dim);
+        var history = historyService.GetAll();
+        if (history.Count == 0)
+        {
+            view.AppendLine("No executions yet.", DarkTheme.Dim);
+            return view;
+        }
+
+        PopulateLogFromHistory(view, history);
         return view;
+    }
+
+    private static void PopulateLogFromHistory(
+        ColoredOutputView view,
+        IReadOnlyList<HistoryEntry> history)
+    {
+        foreach (var entry in history)
+        {
+            var modeLabel = entry.Mode == ExecutionMode.Test ? "TEST" : "APPLY";
+            var statusAttr = entry.Success ? DarkTheme.Green : DarkTheme.Red;
+            var statusLabel = entry.Success ? "PASS" : "FAIL";
+            var ts = entry.Timestamp.ToLocalTime().ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+
+            view.AppendLine(
+                $"  {ts}  {entry.ProfileName,-35} {modeLabel,-6} {statusLabel}  ({entry.DurationSeconds:F1}s)",
+                statusAttr);
+        }
     }
 
     private ColoredOutputView CreateEnvironmentView()
@@ -836,29 +865,22 @@ public sealed class MainWindow : Window
 
         app.Run(executionDialog);
 
-        CaptureExecutionLog(executionDialog);
+        RecordAndRefreshLog(executionDialog);
 
         return Task.CompletedTask;
     }
 
-    private void CaptureExecutionLog(ExecutionDialog dialog)
+    private void RecordAndRefreshLog(ExecutionDialog dialog)
     {
-        var lines = dialog.GetOutputLines();
-        if (lines.Count == 0)
+        var results = dialog.GetResults();
+        foreach (var (fileName, result) in results)
         {
-            return;
+            historyService.RecordAsync(result, fileName).GetAwaiter().GetResult();
         }
 
-        // Clear placeholder text on first real execution
-        if (executionLogView.GetLines().Count == 1)
-        {
-            executionLogView.Clear();
-        }
-
-        foreach (var (text, attr) in lines)
-        {
-            executionLogView.AppendLine(text, attr);
-        }
+        // Rebuild the log view from the full history
+        executionLogView.Clear();
+        PopulateLogFromHistory(executionLogView, historyService.GetAll());
     }
 
     private bool ConfirmExecution(

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -683,7 +683,7 @@ public sealed class MainWindow : Window
             var content = await repository.GetProfileContentAsync(summary.FileName);
             var profile = parser.Parse(content, summary.FileName);
 
-            PopulateOverviewTab(profile);
+            PopulateOverviewTab(profile, summary.FileName);
             PopulateResourcesTab(profile);
 
             // Extensions tab
@@ -703,7 +703,9 @@ public sealed class MainWindow : Window
         }
     }
 
-    private void PopulateOverviewTab(Contracts.Profile profile)
+    private void PopulateOverviewTab(
+        Contracts.Profile profile,
+        string fileName)
     {
         overviewText.Clear();
 
@@ -722,6 +724,76 @@ public sealed class MainWindow : Window
         overviewText.AppendLine(string.Empty, DarkTheme.Default);
         overviewText.AppendLine($"File: {profile.FileName}", DarkTheme.Dim);
         overviewText.AppendLine("Source: GitHub", DarkTheme.Dim);
+
+        AppendLastTestResult(fileName);
+    }
+
+    private void AppendLastTestResult(string fileName)
+    {
+        var all = historyService.GetAll();
+        var lastTest = FindLatest(all, fileName, ExecutionMode.Test);
+        var lastApply = FindLatest(all, fileName, ExecutionMode.Apply);
+
+        if (lastTest is null && lastApply is null)
+        {
+            return;
+        }
+
+        overviewText.AppendLine(string.Empty, DarkTheme.Default);
+
+        var parts = new StringBuilder("History:  ");
+        AppendHistorySegment(parts, "TEST", lastTest);
+
+        if (lastTest is not null && lastApply is not null)
+        {
+            parts.Append("  \u2502  ");
+        }
+
+        AppendHistorySegment(parts, "APPLY", lastApply);
+
+        var attr = GetHistoryLineAttr(lastTest, lastApply);
+        overviewText.AppendLine(parts.ToString(), attr);
+    }
+
+    private static void AppendHistorySegment(
+        StringBuilder sb,
+        string mode,
+        HistoryEntry? entry)
+    {
+        if (entry is null)
+        {
+            return;
+        }
+
+        var symbol = entry.Success ? "\u2713" : "\u2717";
+        var ts = entry.Timestamp.ToLocalTime().ToString("HH:mm", CultureInfo.InvariantCulture);
+        sb.Append(CultureInfo.InvariantCulture, $"{mode} {symbol} {ts}");
+    }
+
+    private static Terminal.Gui.Drawing.Attribute GetHistoryLineAttr(
+        HistoryEntry? test,
+        HistoryEntry? apply)
+    {
+        var anyFailed = (test is not null && !test.Success) ||
+                        (apply is not null && !apply.Success);
+        return anyFailed ? DarkTheme.Red : DarkTheme.Green;
+    }
+
+    private static HistoryEntry? FindLatest(
+        IReadOnlyList<HistoryEntry> all,
+        string fileName,
+        ExecutionMode mode)
+    {
+        for (var i = all.Count - 1; i >= 0; i--)
+        {
+            if (all[i].Mode == mode &&
+                string.Equals(all[i].FileName, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return all[i];
+            }
+        }
+
+        return null;
     }
 
     private void AppendResourceBreakdown(IReadOnlyList<Resource> resources)
@@ -866,6 +938,7 @@ public sealed class MainWindow : Window
         app.Run(executionDialog);
 
         RecordAndRefreshLog(executionDialog);
+        ReloadActiveProfile();
 
         return Task.CompletedTask;
     }
@@ -881,6 +954,15 @@ public sealed class MainWindow : Window
         // Rebuild the log view from the full history
         executionLogView.Clear();
         PopulateLogFromHistory(executionLogView, historyService.GetAll());
+    }
+
+    private void ReloadActiveProfile()
+    {
+        var index = profileList.SelectedItem;
+        if (index is >= 0 && index.Value < filteredIndices.Count)
+        {
+            _ = RunGuardedAsync(() => LoadProfileDetailAsync(filteredIndices[index.Value]));
+        }
     }
 
     private bool ConfirmExecution(

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -27,7 +27,6 @@ public sealed class MainWindow : Window
     private readonly ObservableCollection<string> profileDisplayNames = [];
     private readonly List<ProfileSummary> allProfileSummaries = [];
     private readonly List<int> filteredIndices = [];
-    private bool filterVisible;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MainWindow"/> class.
@@ -84,7 +83,7 @@ public sealed class MainWindow : Window
         var list = new ListView
         {
             X = 0,
-            Y = 0,
+            Y = 1,
             Width = Dim.Fill(),
             Height = Dim.Fill(),
             ShowMarks = true,
@@ -103,12 +102,13 @@ public sealed class MainWindow : Window
         var field = new TextField
         {
             X = 0,
-            Y = Pos.AnchorEnd(1),
+            Y = 0,
             Width = Dim.Fill(),
             Height = 1,
-            Visible = false,
+            Text = string.Empty,
         };
-        field.KeyDown += (_, _) => app.Invoke(ApplyFilter);
+
+        field.TextChanged += (_, _) => ApplyFilter();
         return field;
     }
 
@@ -123,7 +123,7 @@ public sealed class MainWindow : Window
             Height = Dim.Fill(1),
         };
 
-        leftPanel.Add(profileList, filterField);
+        leftPanel.Add(filterField, profileList);
         return leftPanel;
     }
 
@@ -228,7 +228,15 @@ public sealed class MainWindow : Window
 
             if (key == Key.Esc)
             {
-                HandleEscapeKey();
+                if (filterField.HasFocus)
+                {
+                    profileList.SetFocus();
+                }
+                else
+                {
+                    ConfirmQuit();
+                }
+
                 key.Handled = true;
                 return;
             }
@@ -240,18 +248,6 @@ public sealed class MainWindow : Window
 
             HandleNonFilterKey(key);
         };
-    }
-
-    private void HandleEscapeKey()
-    {
-        if (filterVisible)
-        {
-            HideFilter();
-        }
-        else
-        {
-            ConfirmQuit();
-        }
     }
 
     private void HandleNonFilterKey(Key key)
@@ -374,7 +370,7 @@ public sealed class MainWindow : Window
         }
         else if (key == '/')
         {
-            ShowFilter();
+            FocusFilter();
             key.Handled = true;
         }
         else if (key == '?')
@@ -420,8 +416,6 @@ public sealed class MainWindow : Window
         var list = new List<ActionHint>
         {
             new("Space", "Toggle", txt, txt),
-            new("^a", "All", txt, txt),
-            new("^d", "None", txt, txt),
             new("t", "Test", txt, txt),
         };
 
@@ -430,7 +424,6 @@ public sealed class MainWindow : Window
             list.Add(new ActionHint("Enter", "Apply", txt, txt));
         }
 
-        list.Add(new ActionHint("/", "Filter", txt, txt));
         list.Add(new ActionHint("?", "Help", txt, txt));
         list.Add(new ActionHint("q", "Quit", txt, txt));
 
@@ -686,23 +679,9 @@ public sealed class MainWindow : Window
         app.Run(dialog);
     }
 
-    private void ShowFilter()
+    private void FocusFilter()
     {
-        filterVisible = true;
-        filterField.Visible = true;
-        filterField.Text = string.Empty;
-        profileList.Height = Dim.Fill(2);
         filterField.SetFocus();
-    }
-
-    private void HideFilter()
-    {
-        filterVisible = false;
-        filterField.Visible = false;
-        filterField.Text = string.Empty;
-        profileList.Height = Dim.Fill();
-        profileList.SetFocus();
-        ApplyFilter();
     }
 
     private void ApplyFilter()

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -15,6 +15,7 @@ public sealed class MainWindow : Window
     private readonly EnvironmentInfo envInfo;
     private readonly IExecutionHistoryService historyService;
     private readonly ExtensionLoader extensionLoader;
+    private readonly WinGetClient winGetClient = new();
 
     private readonly ListView profileList;
     private readonly TabView detailTabs;
@@ -118,7 +119,9 @@ public sealed class MainWindow : Window
 
         list.KeyDown += (_, key) =>
         {
-            if (key == Key.CursorLeft || key == Key.CursorRight)
+            if (key == Key.CursorLeft || key == Key.CursorRight ||
+                (key == Key.CursorDown && list.SelectedItem == profileDisplayNames.Count - 1) ||
+                (key == Key.CursorUp && list.SelectedItem == 0))
             {
                 key.Handled = true;
             }
@@ -175,7 +178,7 @@ public sealed class MainWindow : Window
             Title = "Profiles",
             X = 0,
             Y = 0,
-            Width = Dim.Percent(28),
+            Width = Dim.Percent(20),
             Height = Dim.Fill(),
         };
 
@@ -310,6 +313,12 @@ public sealed class MainWindow : Window
             : "not found";
         var dscAttr = envInfo.DscCliAvailable ? DarkTheme.Green : DarkTheme.Red;
         view.AppendLine($"  DSC CLI:         {dscLabel}", dscAttr);
+
+        var winGetLabel = envInfo.WinGetAvailable
+            ? envInfo.WinGetVersion ?? "available"
+            : "not found";
+        var winGetAttr = envInfo.WinGetAvailable ? DarkTheme.Green : DarkTheme.Red;
+        view.AppendLine($"  WinGet:          {winGetLabel}", winGetAttr);
 
         view.AppendLine(
             $"  OS:              {Environment.OSVersion}",
@@ -687,7 +696,10 @@ public sealed class MainWindow : Window
             var profile = parser.Parse(content, summary.FileName);
 
             PopulateOverviewTab(profile, summary.FileName);
-            PopulateResourcesTab(profile);
+
+            // Start loading resources tab (winget info loads async)
+            var packages = await winGetClient.GetAllPackagesAsync();
+            PopulateResourcesTab(profile, packages);
 
             // Extensions tab
             extensionsText.Text = await extensionLoader.LoadAsync(summary.FileName);
@@ -853,38 +865,91 @@ public sealed class MainWindow : Window
         _ => type + "s",
     };
 
-    private void PopulateResourcesTab(Contracts.Profile profile)
+    private void PopulateResourcesTab(
+        Contracts.Profile profile,
+        Dictionary<string, WinGetPackageInfo> packages)
     {
         resourcesText.Clear();
 
         var resList = profile.Resources;
 
         resourcesText.AppendLine(
-            $" {"#",2}  {"Name",-37} {"Type",-13}",
+            $" {"#",2}  {"Name",-30} {"Type",-10} {"Status",-14} {"Installed",-14} {"Available",-14}",
             DarkTheme.Header);
         resourcesText.AppendLine(
-            " " + new string('\u2500', 54),
+            " " + new string('\u2500', 86),
             DarkTheme.Dim);
 
         for (var i = 0; i < resList.Count; i++)
         {
-            AppendResourceRow(resList, i);
+            AppendResourceRow(resList, i, packages);
         }
     }
 
     private void AppendResourceRow(
         IReadOnlyList<Resource> resList,
-        int index)
+        int index,
+        Dictionary<string, WinGetPackageInfo> packages)
     {
         var res = resList[index];
-        var name = res.Name.Length > 37 ? res.Name[..36] + "." : res.Name;
+        var name = res.Name.Length > 30 ? res.Name[..29] + "." : res.Name;
         var type = AbbreviateType(res.Type);
-        var typeAttr = GetTypeColor(type);
+
+        if (res.Type == "Microsoft.WinGet/Package")
+        {
+            AppendPackageRow(index, name, type, res, packages);
+        }
+        else
+        {
+            resourcesText.AppendLine(
+                $" {index + 1,2}  {name,-30} {type,-10} {"-",-14}",
+                GetTypeColor(type));
+        }
+
+        AppendDependencyLines(resList, res);
+    }
+
+    private void AppendPackageRow(
+        int index,
+        string name,
+        string type,
+        Resource res,
+        Dictionary<string, WinGetPackageInfo> packages)
+    {
+        var packageId = res.Properties?.TryGetValue("id", out var idObj) == true
+            ? idObj?.ToString() ?? string.Empty
+            : string.Empty;
+
+        if (packageId.Length == 0 ||
+            !packages.TryGetValue(packageId, out var pkg))
+        {
+            resourcesText.AppendLine(
+                $" {index + 1,2}  {name,-30} {type,-10} {"\u25cb not installed",-14}",
+                DarkTheme.Dim);
+            return;
+        }
+
+        var hasUpgrade = pkg.AvailableVersion is not null;
+        var statusLabel = hasUpgrade ? "\u2b06 upgrade" : "\u2713 installed";
+        var statusAttr = hasUpgrade ? DarkTheme.Yellow : DarkTheme.Green;
+        var installed = pkg.InstalledVersion.Length > 14
+            ? pkg.InstalledVersion[..13] + "."
+            : pkg.InstalledVersion;
+        var available = hasUpgrade
+            ? (pkg.AvailableVersion!.Length > 14
+                ? pkg.AvailableVersion[..13] + "."
+                : pkg.AvailableVersion)
+            : string.Empty;
 
         resourcesText.AppendLine(
-            $" {index + 1,2}  {name,-37} {type,-13}",
-            typeAttr);
+            $" {index + 1,2}  {name,-30} {type,-10} {statusLabel,-14} {installed,-14} {available,-14}",
+            statusAttr);
+    }
 
+    private void AppendDependencyLines(
+        IReadOnlyList<Resource> resList,
+        Resource res)
+    {
         foreach (var dep in res.DependsOn)
         {
             var idx = ResolveDependencyIndex(dep, resList);

--- a/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/MainWindow.cs
@@ -23,6 +23,7 @@ public sealed class MainWindow : Window
     private readonly TextView rawYamlText;
     private readonly TextField filterField;
     private readonly ActionHintsView actionHints;
+    private readonly LoadingSpinnerView spinner;
 
     private readonly ObservableCollection<string> profileDisplayNames = [];
     private readonly List<ProfileSummary> allProfileSummaries = [];
@@ -75,6 +76,13 @@ public sealed class MainWindow : Window
         extensionsText = CreateReadOnlyTextView(wordWrap: false);
         rawYamlText = CreateReadOnlyTextView(wordWrap: false);
         detailTabs = CreateDetailTabs();
+        spinner = new LoadingSpinnerView(app)
+        {
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill(),
+            Height = 1,
+        };
         var rightPanel = CreateRightPanel(leftPanel);
 
         actionHints = CreateActionHints();
@@ -176,7 +184,7 @@ public sealed class MainWindow : Window
             Height = Dim.Fill(1),
         };
 
-        rightPanel.Add(detailTabs);
+        rightPanel.Add(detailTabs, spinner);
         return rightPanel;
     }
 
@@ -196,6 +204,8 @@ public sealed class MainWindow : Window
 
     private async Task LoadProfilesAsync()
     {
+        spinner.Label = "Loading profiles...";
+        spinner.Start();
         try
         {
             var summaries = await repository.ListProfilesAsync();
@@ -222,6 +232,10 @@ public sealed class MainWindow : Window
         {
             overviewText.Clear();
             overviewText.AppendLine($"Error loading profiles: {ex.Message}", DarkTheme.Red);
+        }
+        finally
+        {
+            spinner.Stop();
         }
     }
 
@@ -474,6 +488,8 @@ public sealed class MainWindow : Window
 
         var summary = allProfileSummaries[index];
 
+        spinner.Label = $"Loading {summary.Name}...";
+        spinner.Start();
         try
         {
             var content = await repository.GetProfileContentAsync(summary.FileName);
@@ -492,6 +508,10 @@ public sealed class MainWindow : Window
         {
             overviewText.Clear();
             overviewText.AppendLine($"Error loading profile: {ex.Message}", DarkTheme.Red);
+        }
+        finally
+        {
+            spinner.Stop();
         }
     }
 

--- a/src/Atc.Dsc.Configurations.Cli/Tui/TerminalGuiRunner.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/TerminalGuiRunner.cs
@@ -36,6 +36,7 @@ public sealed class TerminalGuiRunner : IInteractiveRunner
     public Task<int> RunAsync(CancellationToken cancellationToken = default)
     {
         using var app = Application.Create().Init();
+        DarkTheme.Register();
         using var registration = cancellationToken.Register(() => app.Invoke(() => app.RequestStop()));
 
         var mainWindow = new MainWindow(app, repository, parser, dscClient, envInfo);

--- a/src/Atc.Dsc.Configurations.Cli/Tui/TerminalGuiRunner.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/TerminalGuiRunner.cs
@@ -12,6 +12,7 @@ public sealed class TerminalGuiRunner : IInteractiveRunner
     private readonly IProfileParser parser;
     private readonly IDscClient dscClient;
     private readonly EnvironmentInfo envInfo;
+    private readonly IExecutionHistoryService historyService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TerminalGuiRunner"/> class.
@@ -20,16 +21,19 @@ public sealed class TerminalGuiRunner : IInteractiveRunner
     /// <param name="parser">the parser for profile content.</param>
     /// <param name="dscClient">the DSC client.</param>
     /// <param name="envInfo">the current environment information.</param>
+    /// <param name="historyService">the execution history service.</param>
     public TerminalGuiRunner(
         IProfileRepository repository,
         IProfileParser parser,
         IDscClient dscClient,
-        EnvironmentInfo envInfo)
+        EnvironmentInfo envInfo,
+        IExecutionHistoryService historyService)
     {
         this.repository = repository;
         this.parser = parser;
         this.dscClient = dscClient;
         this.envInfo = envInfo;
+        this.historyService = historyService;
     }
 
     /// <inheritdoc />
@@ -39,7 +43,7 @@ public sealed class TerminalGuiRunner : IInteractiveRunner
         DarkTheme.Register();
         using var registration = cancellationToken.Register(() => app.Invoke(() => app.RequestStop()));
 
-        var mainWindow = new MainWindow(app, repository, parser, dscClient, envInfo);
+        var mainWindow = new MainWindow(app, repository, parser, dscClient, envInfo, historyService);
 
         app.Run(mainWindow);
 

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Theme/DarkTheme.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Theme/DarkTheme.cs
@@ -1,0 +1,124 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Theme;
+
+/// <summary>
+/// Centralized dark theme with consistent black-background color attributes
+/// for all TUI views. Inspired by the winget-tui aesthetic.
+/// </summary>
+internal static class DarkTheme
+{
+    // Base palette — all on black background
+    internal static Terminal.Gui.Drawing.Attribute Default { get; } = new(ColorName16.Gray, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Header { get; } = new(ColorName16.White, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Green { get; } = new(ColorName16.BrightGreen, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Red { get; } = new(ColorName16.BrightRed, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Yellow { get; } = new(ColorName16.BrightYellow, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Cyan { get; } = new(ColorName16.BrightCyan, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Blue { get; } = new(ColorName16.BrightBlue, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute Dim { get; } = new(ColorName16.DarkGray, ColorName16.Black);
+
+    // Semantic — status bar
+    internal static Terminal.Gui.Drawing.Attribute StatusBar { get; } = new(ColorName16.Gray, ColorName16.DarkGray);
+
+    internal static Terminal.Gui.Drawing.Attribute StatusBarKey { get; } = new(ColorName16.White, ColorName16.DarkGray);
+
+    internal static Terminal.Gui.Drawing.Attribute StatusBarHighlight { get; } = new(ColorName16.BrightYellow, ColorName16.DarkGray);
+
+    // Semantic — list selection: purple bg when focused, green text when unfocused
+    private static readonly Terminal.Gui.Drawing.Color PurpleBg = new(120, 80, 200);
+
+    internal static Terminal.Gui.Drawing.Attribute ListItemFocused { get; }
+        = new(new Terminal.Gui.Drawing.Color(255, 255, 255), PurpleBg);
+
+    private static readonly Terminal.Gui.Drawing.Color MossGreenBg = new(80, 160, 80);
+
+    internal static Terminal.Gui.Drawing.Attribute ListItemUnfocused { get; }
+        = new(new Terminal.Gui.Drawing.Color(0, 0, 0), MossGreenBg);
+
+    // Semantic — frame borders
+    internal static Terminal.Gui.Drawing.Attribute FrameBorder { get; } = new(ColorName16.DarkGray, ColorName16.Black);
+
+    // Semantic — tabs
+    internal static Terminal.Gui.Drawing.Attribute TabActive { get; } = new(ColorName16.BrightCyan, ColorName16.Black);
+
+    internal static Terminal.Gui.Drawing.Attribute TabInactive { get; } = new(ColorName16.DarkGray, ColorName16.Black);
+
+    // Action button colors
+    internal static Terminal.Gui.Drawing.Attribute ActionTest { get; } = new(ColorName16.Black, ColorName16.BrightCyan);
+
+    internal static Terminal.Gui.Drawing.Attribute ActionApply { get; } = new(ColorName16.Black, ColorName16.BrightGreen);
+
+    /// <summary>
+    /// Registers dark theme by overriding the built-in schemes.
+    /// Must be called after <c>Application.Init()</c>.
+    /// </summary>
+    internal static void Register()
+    {
+        // Override the built-in "Base" scheme so all views inherit dark colors
+        var darkBase = new Scheme
+        {
+            Normal = Header,
+            Focus = Header,
+            HotNormal = Cyan,
+            HotFocus = Cyan,
+            Disabled = Dim,
+        };
+
+        Terminal.Gui.Configuration.SchemeManager.AddScheme(
+            nameof(Schemes.Base),
+            darkBase);
+
+        // Override the built-in "Dialog" scheme
+        var darkDialog = new Scheme
+        {
+            Normal = Header,
+            Focus = Header,
+            HotNormal = Cyan,
+            HotFocus = Cyan,
+            Disabled = Dim,
+        };
+
+        Terminal.Gui.Configuration.SchemeManager.AddScheme(
+            nameof(Schemes.Dialog),
+            darkDialog);
+
+        // Override the built-in "Menu" scheme (status bar, menus)
+        var darkMenu = new Scheme
+        {
+            Normal = StatusBar,
+            Focus = StatusBarKey,
+            HotNormal = new Terminal.Gui.Drawing.Attribute(ColorName16.BrightCyan, ColorName16.DarkGray),
+            HotFocus = new Terminal.Gui.Drawing.Attribute(ColorName16.BrightCyan, ColorName16.DarkGray),
+            Disabled = Dim,
+        };
+
+        Terminal.Gui.Configuration.SchemeManager.AddScheme(
+            nameof(Schemes.Menu),
+            darkMenu);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Scheme"/> for the profile list.
+    /// Purple background when the list has focus (Focus role),
+    /// green text when unfocused (Active role).
+    /// Must be applied via <c>SetScheme()</c> on the ListView.
+    /// </summary>
+    /// <returns>A configured <see cref="Scheme"/> for list views.</returns>
+    internal static Scheme CreateListScheme()
+        => new()
+        {
+            Normal = Header,
+            Focus = ListItemFocused,
+            Active = ListItemUnfocused,
+            HotNormal = Header,
+            HotFocus = ListItemFocused,
+            HotActive = ListItemUnfocused,
+            Disabled = Dim,
+        };
+}

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Views/ActionHint.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Views/ActionHint.cs
@@ -1,0 +1,14 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Views;
+
+/// <summary>
+/// Represents a single action hint segment displayed in the status bar.
+/// </summary>
+/// <param name="Key">The key label (e.g. "Space", "t", "Enter").</param>
+/// <param name="Label">The action description (e.g. "Toggle", "Test", "Apply").</param>
+/// <param name="KeyAttr">The color attribute for the key portion.</param>
+/// <param name="LabelAttr">The color attribute for the label portion.</param>
+internal record ActionHint(
+    string Key,
+    string Label,
+    Terminal.Gui.Drawing.Attribute KeyAttr,
+    Terminal.Gui.Drawing.Attribute LabelAttr);

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Views/ActionHintsView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Views/ActionHintsView.cs
@@ -1,0 +1,85 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Views;
+
+/// <summary>
+/// Renders a horizontal bar of colored action hint segments.
+/// Each segment shows a key and label with distinct color attributes,
+/// separated by spaces in the status bar background color.
+/// </summary>
+internal sealed class ActionHintsView : View
+{
+    private static Terminal.Gui.Drawing.Attribute GapAttr
+        => DarkTheme.StatusBar;
+
+    private IReadOnlyList<ActionHint> hints = [];
+
+    /// <summary>
+    /// Sets the action hints to display and triggers a redraw.
+    /// </summary>
+    /// <param name="value">The list of action hints to render.</param>
+    internal void SetHints(IReadOnlyList<ActionHint> value)
+    {
+        hints = value;
+        SetNeedsDraw();
+    }
+
+    /// <inheritdoc />
+    protected override bool OnDrawingContent(DrawContext? context)
+    {
+        var vp = Viewport;
+        var col = 0;
+
+        for (var i = 0; i < hints.Count; i++)
+        {
+            var hint = hints[i];
+            var keyText = hint.Key;
+            var labelText = " " + hint.Label;
+
+            // Draw key portion
+            col = DrawSegment(keyText, hint.KeyAttr, col, vp.Width);
+
+            // Draw label portion
+            col = DrawSegment(labelText, hint.LabelAttr, col, vp.Width);
+
+            // Draw gap between hints
+            if (i < hints.Count - 1)
+            {
+                col = DrawSegment(" ", GapAttr, col, vp.Width);
+            }
+        }
+
+        // Fill remaining width with status bar background
+        if (col < vp.Width)
+        {
+            Move(col, 0);
+            SetAttribute(GapAttr);
+            AddStr(new string(' ', vp.Width - col));
+        }
+
+        return true;
+    }
+
+    private int DrawSegment(
+        string text,
+        Terminal.Gui.Drawing.Attribute attr,
+        int col,
+        int maxWidth)
+    {
+        if (col >= maxWidth)
+        {
+            return col;
+        }
+
+        Move(col, 0);
+        SetAttribute(attr);
+
+        var available = maxWidth - col;
+        if (text.Length > available)
+        {
+            AddStr(text[..available]);
+            return maxWidth;
+        }
+
+        AddStr(text);
+        return col + text.Length;
+    }
+}

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Views/LoadingSpinnerView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Views/LoadingSpinnerView.cs
@@ -1,0 +1,104 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Views;
+
+/// <summary>
+/// Displays a braille dot spinner animation with a text label.
+/// Uses a timer to cycle through frames at 80ms intervals.
+/// </summary>
+internal sealed class LoadingSpinnerView : View
+{
+    private static readonly string[] Frames =
+        ["\u280b", "\u2819", "\u2839", "\u2838", "\u283c", "\u2834", "\u2826", "\u2827", "\u2807", "\u280f"];
+
+    private readonly IApplication app;
+    private Timer? timer;
+    private int frameIndex;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoadingSpinnerView"/> class.
+    /// </summary>
+    /// <param name="app">the Terminal.Gui application instance for UI thread dispatch.</param>
+    public LoadingSpinnerView(IApplication app)
+    {
+        this.app = app;
+        CanFocus = false;
+        Visible = false;
+    }
+
+    /// <summary>
+    /// Gets or sets the label text shown next to the spinner.
+    /// </summary>
+    internal string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Starts the spinner animation.
+    /// </summary>
+    internal void Start()
+    {
+        frameIndex = 0;
+        Visible = true;
+        timer?.Dispose();
+        timer = new Timer(OnTick, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(80));
+    }
+
+    /// <summary>
+    /// Stops the spinner animation and hides the view.
+    /// </summary>
+    internal void Stop()
+    {
+        timer?.Dispose();
+        timer = null;
+        Visible = false;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            disposed = true;
+            timer?.Dispose();
+            timer = null;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc />
+    protected override bool OnDrawingContent(DrawContext? context)
+    {
+        var vp = Viewport;
+        Move(0, 0);
+        SetAttribute(DarkTheme.Cyan);
+        AddStr(Frames[frameIndex % Frames.Length]);
+
+        SetAttribute(DarkTheme.Default);
+        var text = " " + Label;
+        if (text.Length > vp.Width - 1)
+        {
+            text = text[..(vp.Width - 1)];
+        }
+
+        AddStr(text);
+
+        var used = 1 + text.Length;
+        if (used < vp.Width)
+        {
+            SetAttribute(DarkTheme.Default);
+            AddStr(new string(' ', vp.Width - used));
+        }
+
+        return true;
+    }
+
+    private void OnTick(object? state)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        frameIndex = (frameIndex + 1) % Frames.Length;
+        app.Invoke(() => SetNeedsDraw());
+    }
+}

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Views/ProfileQueueView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Views/ProfileQueueView.cs
@@ -1,0 +1,208 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Views;
+
+/// <summary>
+/// Displays the execution queue with per-profile status icons and a
+/// progress bar. Running items show an animated braille spinner.
+/// </summary>
+internal sealed class ProfileQueueView : View
+{
+    private static readonly string[] SpinnerFrames =
+        ["\u280b", "\u2819", "\u2839", "\u2838", "\u283c", "\u2834", "\u2826", "\u2827", "\u2807", "\u280f"];
+
+    private readonly IApplication app;
+    private string[] names = [];
+    private QueueItemStatus[] statuses = [];
+    private int completed;
+    private int total;
+    private int spinnerFrame;
+    private Timer? spinnerTimer;
+    private bool disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProfileQueueView"/> class.
+    /// </summary>
+    /// <param name="app">the application instance for UI thread dispatch.</param>
+    public ProfileQueueView(IApplication app)
+    {
+        this.app = app;
+        CanFocus = false;
+    }
+
+    /// <summary>
+    /// Sets the profile list and starts the spinner timer.
+    /// </summary>
+    /// <param name="profiles">the profiles to display.</param>
+    internal void SetProfiles(IReadOnlyList<ProfileSummary> profiles)
+    {
+        names = new string[profiles.Count];
+        statuses = new QueueItemStatus[profiles.Count];
+        total = profiles.Count;
+
+        for (var i = 0; i < profiles.Count; i++)
+        {
+            names[i] = TruncateName(profiles[i].Name);
+            statuses[i] = QueueItemStatus.Queued;
+        }
+
+        spinnerTimer?.Dispose();
+        spinnerTimer = new Timer(
+            OnSpinnerTick,
+            null,
+            TimeSpan.Zero,
+            TimeSpan.FromMilliseconds(80));
+    }
+
+    /// <summary>
+    /// Updates a profile's queue status.
+    /// </summary>
+    /// <param name="index">the zero-based profile index.</param>
+    /// <param name="status">the new status.</param>
+    internal void UpdateStatus(
+        int index,
+        QueueItemStatus status)
+    {
+        if (index >= 0 && index < statuses.Length)
+        {
+            statuses[index] = status;
+            if (status is QueueItemStatus.Passed or QueueItemStatus.Failed)
+            {
+                completed++;
+            }
+
+            app.Invoke(() => SetNeedsDraw());
+        }
+    }
+
+    /// <summary>
+    /// Stops the spinner timer. Call when execution completes.
+    /// </summary>
+    internal void StopSpinner()
+    {
+        spinnerTimer?.Dispose();
+        spinnerTimer = null;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            disposed = true;
+            spinnerTimer?.Dispose();
+            spinnerTimer = null;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc />
+    protected override bool OnDrawingContent(DrawContext? context)
+    {
+        var vp = Viewport;
+
+        for (var row = 0; row < vp.Height; row++)
+        {
+            Move(0, row);
+
+            if (row < names.Length)
+            {
+                DrawQueueItem(row, vp.Width);
+            }
+            else if (row == names.Length + 1)
+            {
+                DrawProgressBar(vp.Width);
+            }
+            else
+            {
+                SetAttribute(DarkTheme.Default);
+                AddStr(new string(' ', vp.Width));
+            }
+        }
+
+        return true;
+    }
+
+    private void DrawQueueItem(
+        int index,
+        int width)
+    {
+        var (symbol, attr) = GetSymbolAndAttr(statuses[index]);
+
+        SetAttribute(attr);
+        AddStr($" {symbol} ");
+
+        var nameAttr = statuses[index] == QueueItemStatus.Running
+            ? DarkTheme.Header
+            : DarkTheme.Default;
+        SetAttribute(nameAttr);
+
+        var name = names[index];
+        AddStr(name);
+
+        var used = 3 + name.Length;
+        if (used < width)
+        {
+            SetAttribute(DarkTheme.Default);
+            AddStr(new string(' ', width - used));
+        }
+    }
+
+    private void DrawProgressBar(int width)
+    {
+        if (total == 0)
+        {
+            SetAttribute(DarkTheme.Default);
+            AddStr(new string(' ', width));
+            return;
+        }
+
+        var label = $" {completed}/{total} ";
+        var barWidth = width - label.Length - 1;
+        if (barWidth < 1)
+        {
+            barWidth = 1;
+        }
+
+        var filled = total > 0 ? (int)(barWidth * ((double)completed / total)) : 0;
+        var empty = barWidth - filled;
+
+        SetAttribute(DarkTheme.Green);
+        AddStr(" ");
+        AddStr(new string('\u2588', filled));
+
+        SetAttribute(DarkTheme.Dim);
+        AddStr(new string('\u2591', empty));
+
+        SetAttribute(DarkTheme.Default);
+        AddStr(label);
+    }
+
+    private (string Symbol, Terminal.Gui.Drawing.Attribute Attr) GetSymbolAndAttr(
+        QueueItemStatus status) => status switch
+    {
+        QueueItemStatus.Queued => ("\u25cb", DarkTheme.Dim),
+        QueueItemStatus.Running => (
+            SpinnerFrames[spinnerFrame % SpinnerFrames.Length],
+            DarkTheme.Cyan),
+        QueueItemStatus.Passed => ("\u2713", DarkTheme.Green),
+        QueueItemStatus.Failed => ("\u2717", DarkTheme.Red),
+        _ => ("?", DarkTheme.Default),
+    };
+
+    private static string TruncateName(string name)
+    {
+        var label = name.Replace(" configuration", string.Empty, StringComparison.OrdinalIgnoreCase);
+        return label.Length > 20 ? label[..19] + "." : label;
+    }
+
+    private void OnSpinnerTick(object? state)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        spinnerFrame = (spinnerFrame + 1) % SpinnerFrames.Length;
+        app.Invoke(() => SetNeedsDraw());
+    }
+}

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Views/QueueItemStatus.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Views/QueueItemStatus.cs
@@ -1,0 +1,12 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Views;
+
+/// <summary>
+/// Status of a profile in the execution queue.
+/// </summary>
+internal enum QueueItemStatus
+{
+    Queued,
+    Running,
+    Passed,
+    Failed,
+}

--- a/src/Atc.Dsc.Configurations.Cli/Tui/Views/TopTabBarView.cs
+++ b/src/Atc.Dsc.Configurations.Cli/Tui/Views/TopTabBarView.cs
@@ -1,0 +1,95 @@
+namespace Atc.Dsc.Configurations.Cli.Tui.Views;
+
+/// <summary>
+/// Renders a horizontal top tab bar with colored dot indicators
+/// on a black background. Active tab is bright, inactive tabs are dim.
+/// </summary>
+internal sealed class TopTabBarView : View
+{
+    private readonly string[] labels;
+    private int activeIndex;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TopTabBarView"/> class.
+    /// </summary>
+    /// <param name="labels">the tab label strings.</param>
+    public TopTabBarView(string[] labels)
+    {
+        this.labels = labels;
+        CanFocus = false;
+    }
+
+    /// <summary>
+    /// Sets the active tab index and redraws.
+    /// </summary>
+    /// <param name="index">the zero-based tab index.</param>
+    internal void SetActive(int index)
+    {
+        activeIndex = index;
+        SetNeedsDraw();
+    }
+
+    /// <inheritdoc />
+    protected override bool OnDrawingContent(DrawContext? context)
+    {
+        var vp = Viewport;
+        Move(0, 0);
+
+        var col = 0;
+
+        for (var i = 0; i < labels.Length; i++)
+        {
+            var isActive = i == activeIndex;
+            col += DrawTab(i, isActive, col, vp.Width);
+        }
+
+        // Fill remaining width
+        if (col < vp.Width)
+        {
+            SetAttribute(DarkTheme.Default);
+            AddStr(new string(' ', vp.Width - col));
+        }
+
+        return true;
+    }
+
+    private int DrawTab(
+        int index,
+        bool isActive,
+        int col,
+        int maxWidth)
+    {
+        // " ● Label (N)  " pattern
+        var dot = isActive ? "\u25cf" : "\u25cb";
+        var prefix = $" {dot} ";
+        var hint = $" ({index + 1})";
+        var suffix = "  ";
+        var text = prefix + labels[index] + hint + suffix;
+
+        if (col + text.Length > maxWidth)
+        {
+            text = text[..(maxWidth - col)];
+        }
+
+        var dotAttr = isActive ? DarkTheme.Green : DarkTheme.Dim;
+        var labelAttr = isActive ? DarkTheme.Header : DarkTheme.Dim;
+
+        // Draw dot
+        SetAttribute(dotAttr);
+        AddStr(prefix);
+
+        // Draw label
+        SetAttribute(labelAttr);
+        AddStr(labels[index]);
+
+        // Draw key hint
+        SetAttribute(DarkTheme.Dim);
+        AddStr($" ({index + 1})");
+
+        // Draw suffix spacing
+        SetAttribute(DarkTheme.Default);
+        AddStr(suffix);
+
+        return text.Length;
+    }
+}

--- a/test/Atc.Dsc.Configurations.Cli.Tests/Clients/WinGetClientTests.cs
+++ b/test/Atc.Dsc.Configurations.Cli.Tests/Clients/WinGetClientTests.cs
@@ -1,0 +1,66 @@
+namespace Atc.Dsc.Configurations.Cli.Tests.Clients;
+
+public sealed class WinGetClientTests
+{
+    [Fact]
+    public void ParseWinGetListOutput_CleanTable_ParsesCorrectly()
+    {
+        // Arrange — columns aligned exactly like real winget output
+        //                         0         1         2         3         4         5
+        //                         0123456789012345678901234567890123456789012345678901234567
+        var output =
+            "Name                     Id                  Version      Available\n" +
+            "--------------------------------------------------------------------\n" +
+            "7-Zip 25.01 (x64)        7zip.7zip           25.01        26.00\n" +
+            "Git                      Git.Git             2.53.0.2\n" +
+            "Fork                     Fork.Fork           2.17.1\n";
+
+        // Act
+        var result = WinGetClient.ParseWinGetListOutput(output);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.True(result.TryGetValue("7zip.7zip", out var zip));
+        Assert.Equal("25.01", zip!.InstalledVersion);
+        Assert.Equal("26.00", zip.AvailableVersion);
+
+        Assert.True(result.TryGetValue("Git.Git", out var git));
+        Assert.Equal("2.53.0.2", git!.InstalledVersion);
+        Assert.Null(git.AvailableVersion);
+    }
+
+    [Fact]
+    public void ParseWinGetListOutput_WithProgressChars_ParsesCorrectly()
+    {
+        // Arrange — simulated progress + header on same line
+        var output =
+            "\r   - \r   \\ \r\rName                Id                Version    Available\r\n" +
+            "-----------------------------------------------------------\r\n" +
+            "Git                 Git.Git            2.53.0.2\r\n";
+
+        // Act
+        var result = WinGetClient.ParseWinGetListOutput(output);
+
+        // Assert
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("Git.Git"));
+    }
+
+    [Fact]
+    public void ParseWinGetListOutput_EmptyOutput_ReturnsEmpty()
+    {
+        var result = WinGetClient.ParseWinGetListOutput(string.Empty);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CleanProgressOutput_StripsCarriageReturns()
+    {
+        var input = "\r   - \r   \\ \r   | \rName  Id  Version\r\n---\r\n";
+
+        var cleaned = WinGetClient.CleanProgressOutput(input);
+
+        Assert.Contains("Name", cleaned, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\", cleaned, StringComparison.Ordinal);
+    }
+}

--- a/test/Atc.Dsc.Configurations.Cli.Tests/Diagnostics/EnvironmentDetectorTests.cs
+++ b/test/Atc.Dsc.Configurations.Cli.Tests/Diagnostics/EnvironmentDetectorTests.cs
@@ -46,7 +46,9 @@ public sealed class EnvironmentDetectorTests
         var info = new EnvironmentInfo(
             IsAdmin: false,
             DscCliAvailable: dscCliAvailable,
-            DscCliVersion: version);
+            DscCliVersion: version,
+            WinGetAvailable: true,
+            WinGetVersion: null);
 
         // Act & Assert
         Assert.Equal(expected, info.DscCliAvailable);

--- a/test/Atc.Dsc.Configurations.Cli.Tests/GlobalUsings.cs
+++ b/test/Atc.Dsc.Configurations.Cli.Tests/GlobalUsings.cs
@@ -6,4 +6,5 @@ global using Atc.Dsc.Configurations.Cli.Diagnostics;
 global using Atc.Dsc.Configurations.Cli.Extensions;
 global using Atc.Dsc.Configurations.Cli.Parsers;
 global using Atc.Dsc.Configurations.Cli.Repositories;
+global using Atc.Dsc.Configurations.Cli.Services;
 global using Atc.Dsc.Configurations.Cli.Tui;

--- a/test/Atc.Dsc.Configurations.Cli.Tests/Services/ExecutionHistoryServiceTests.cs
+++ b/test/Atc.Dsc.Configurations.Cli.Tests/Services/ExecutionHistoryServiceTests.cs
@@ -1,0 +1,85 @@
+namespace Atc.Dsc.Configurations.Cli.Tests.Services;
+
+public sealed class ExecutionHistoryServiceTests : IDisposable
+{
+    private readonly string tempDir;
+    private readonly JsonSerializerOptions jsonOptions;
+
+    public ExecutionHistoryServiceTests()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "atc-dsc-test-" + Guid.NewGuid().ToString("N")[..8]);
+        jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    }
+
+    [Fact]
+    public void GetAll_EmptyHistory_ReturnsEmpty()
+    {
+        using var svc = CreateService();
+        Assert.Empty(svc.GetAll());
+    }
+
+    [Fact]
+    public async Task RecordAsync_AddsEntry()
+    {
+        using var svc = CreateService();
+
+        await svc.RecordAsync(CreateResult(true), "test.dsc.yaml");
+
+        var all = svc.GetAll();
+        Assert.Single(all);
+        Assert.Equal("test.dsc.yaml", all[0].FileName);
+        Assert.True(all[0].Success);
+    }
+
+    [Fact]
+    public async Task GetLatest_ReturnsNewest()
+    {
+        using var svc = CreateService();
+
+        await svc.RecordAsync(CreateResult(false), "a.dsc.yaml");
+        await svc.RecordAsync(CreateResult(true), "a.dsc.yaml");
+
+        var latest = svc.GetLatest("a.dsc.yaml");
+        Assert.NotNull(latest);
+        Assert.True(latest.Success);
+    }
+
+    [Fact]
+    public void GetLatest_NoMatch_ReturnsNull()
+    {
+        using var svc = CreateService();
+        Assert.Null(svc.GetLatest("nonexistent.dsc.yaml"));
+    }
+
+    [Fact]
+    public async Task RecordAsync_TrimsAtMaxEntries()
+    {
+        using var svc = CreateService();
+
+        for (var i = 0; i < ExecutionHistoryService.MaxEntries + 10; i++)
+        {
+            await svc.RecordAsync(CreateResult(true), $"p{i}.dsc.yaml");
+        }
+
+        Assert.Equal(ExecutionHistoryService.MaxEntries, svc.GetAll().Count);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private ExecutionHistoryService CreateService()
+        => new(jsonOptions, tempDir);
+
+    private static ExecutionResult CreateResult(bool success)
+        => new(
+            "test profile",
+            ExecutionMode.Test,
+            success,
+            [new ResourceResult("r1", "Package", success ? ResourceState.Compliant : ResourceState.Failed, null)],
+            TimeSpan.FromSeconds(1.5));
+}

--- a/test/Atc.Dsc.Configurations.Cli.Tests/Tui/MainWindowTests.cs
+++ b/test/Atc.Dsc.Configurations.Cli.Tests/Tui/MainWindowTests.cs
@@ -30,6 +30,36 @@ public sealed class MainWindowTests
         Assert.Equal(expected, MainWindow.ResolveDependencyIndex(dependency, resources));
     }
 
+    [Fact]
+    public void GroupResourcesByType_GroupsAndSortsDescending()
+    {
+        // Arrange
+        var resources = new List<Resource>
+        {
+            new("git", "Microsoft.WinGet/Package", [], null),
+            new("node", "Microsoft.WinGet/Package", [], null),
+            new("setup", "Microsoft.DSC.Transitional/RunCommandOnSet", [], null),
+            new("vs", "Microsoft.VisualStudio.DSC/VSComponents", [], null),
+            new("dotnet", "Microsoft.WinGet/Package", [], null),
+        };
+
+        // Act
+        var result = MainWindow.GroupResourcesByType(resources);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(("Package", 3), result[0]);
+        Assert.Equal(("Script", 1), result[1]);
+        Assert.Equal(("VS Config", 1), result[2]);
+    }
+
+    [Fact]
+    public void GroupResourcesByType_EmptyList_ReturnsEmpty()
+    {
+        var result = MainWindow.GroupResourcesByType([]);
+        Assert.Empty(result);
+    }
+
     public static TheoryData<string, IReadOnlyList<Resource>, int?>
         ResolveDependencyIndexData
         => new()


### PR DESCRIPTION
Major TUI overhaul for the atc-dsc CLI tool. Introduces a dark theme, three-page tab navigation (Profiles, Execution Log, Environment), execution history persistence across sessions, and WinGet package status detection showing installed versions and available upgrades per profile resource.

:sparkles: Features

- Dark theme — centralized DarkTheme class with purple/green selection highlights, consistent black-background palette across all views
- Top-level tab bar — three pages (Profiles/Configurations, Execution Log, Environment) with colored dot indicators and 1/2/3 keyboard shortcuts
- Resource type breakdown — Overview tab shows colored ■ squares grouped by type (Package, Script, PowerShell, etc.) with counts
- Loading spinners — braille dot animation (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) during profile fetching and detail loading
- Execution queue sidebar — multi-profile test/apply shows a left sidebar with per-profile status (○ queued → ⠹ running → ✓/✗ done) and a block progress bar
- Execution history — results persisted to ~/.atc-dsc/history.json, survives across sessions, capped at 500 entries
- History in Overview — compact one-line display: History: TEST ✓ 12:40 │ APPLY ✗ 11:25
- WinGet package status — Resources tab shows installed/upgrade/not-installed status per WinGet package with version columns, parsed from winget list output
- Dependency tree view — Resources tab shows dependencies as indented └─ depends on: lines with dim coloring
- Always-visible filter — filter field pinned at top of profile list, cleaner status bar
- Streamlined profile names — strip " configuration" suffix, narrow left panel to 20%

:bug: Fixes

- Fix startup race condition causing "Collection was modified" error on first profile load
- Serve stale cache on network error instead of propagating HttpRequestException
- Cache extension 404s to prevent repeated HTTP calls for missing files
- Block arrow keys past first/last item and left/right on profile list
- Immediate status bar update on Space mark toggle

:memo: Documentation

- Add known issue for DSC v3 preview.12 JSON trailing characters bug with workaround

:wrench: Configuration

- Add WinGet availability check to EnvironmentInfo and Environment tab