### PR TITLE
Add Aspire DSC configuration profile

### DIFF
--- a/configurations/aspire-configuration-vscode-extensions.json
+++ b/configurations/aspire-configuration-vscode-extensions.json
@@ -1,0 +1,6 @@
+{
+  "extensions":
+  [
+    { "name": "microsoft-aspire.aspire-vscode", "description": "The official Aspire extension for VS Code. Run, debug, and deploy your Aspire apps. Supports building distributed apps with microservices, databases, containers, and frontends, with debugging for C#, Python, Node.js, and more" }
+  ]
+}

--- a/configurations/aspire-configuration.dsc.yaml
+++ b/configurations/aspire-configuration.dsc.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json
+
+##########################################################################################################
+# NOTE: Run: dsc config set --file .\configurations\aspire-configuration.dsc.yaml                        #
+##########################################################################################################
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+metadata:
+  description: Install tools for .NET Aspire development
+  winget:
+    processor:
+      identifier: dscv3
+resources:
+  - name: Install NET Aspire
+    type: Microsoft.WinGet/Package
+    properties:
+      id: Microsoft.Aspire
+      source: winget
+  - name: Install Visual Studio Code
+    type: Microsoft.WinGet/Package
+    properties:
+      id: Microsoft.VisualStudioCode
+      source: winget
+  - name: Install VSCode Extensions
+    type: Microsoft.DSC.Transitional/RunCommandOnSet
+    dependsOn:
+      - "[resourceId('Microsoft.WinGet/Package', 'Install Visual Studio Code')]"
+    properties:
+      executable: pwsh
+      arguments:
+        - -NoProfile
+        - -Command
+        - |
+          $env:NODE_OPTIONS="--no-deprecation"
+          $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+          $jsonContent = Get-Content '${WinGetConfigRoot}\aspire-configuration-vscode-extensions.json' -Raw
+          $extensions = (ConvertFrom-Json $jsonContent).extensions
+          $installedExtensions = code --list-extensions
+          foreach ($extension in $extensions) {
+            if ($installedExtensions -notcontains $extension.name) {
+              code --install-extension $extension.name
+            }
+          }
+      exitCode: 0


### PR DESCRIPTION
:sparkles: Features

- Add aspire-configuration.dsc.yaml profile that installs Microsoft.Aspire and VS Code via WinGet
- Add aspire-configuration-vscode-extensions.json with the microsoft-aspire.aspire-vscode extension